### PR TITLE
feat(MAN-12): implement agent blocking for discrepancies and aging

### DIFF
--- a/backend/prisma/migrations/20260121063934_add_agent_blocking_fields/migration.sql
+++ b/backend/prisma/migrations/20260121063934_add_agent_blocking_fields/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "agent_balances" ADD COLUMN     "block_reason" TEXT,
+ADD COLUMN     "blocked_at" TIMESTAMP(3),
+ADD COLUMN     "blocked_by_id" INTEGER,
+ADD COLUMN     "is_blocked" BOOLEAN NOT NULL DEFAULT false;
+
+-- AddForeignKey
+ALTER TABLE "agent_balances" ADD CONSTRAINT "agent_balances_blocked_by_id_fkey" FOREIGN KEY ("blocked_by_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -48,6 +48,7 @@ model User {
   deposits              AgentDeposit[]    @relation("AgentDeposits")
   verifiedDeposits      AgentDeposit[]    @relation("VerifiedDeposits")
   agingBucket           AgentAgingBucket?
+  blockedBalances       AgentBalance[]    @relation("BlockedBy")
 
   @@index([role, isActive])
   @@index([role, isActive, isAvailable])
@@ -756,10 +757,15 @@ model AgentBalance {
   totalDeposited     Decimal  @default(0) @map("total_deposited") @db.Decimal(19, 4)
   currentBalance     Decimal  @default(0) @map("current_balance") @db.Decimal(19, 4)
   lastSettlementDate DateTime? @map("last_settlement_date")
+  isBlocked          Boolean  @default(false) @map("is_blocked")
+  blockReason        String?  @map("block_reason")
+  blockedAt          DateTime? @map("blocked_at")
+  blockedById        Int?     @map("blocked_by_id")
   createdAt          DateTime @default(now()) @map("created_at")
   updatedAt          DateTime @updatedAt @map("updated_at")
 
-  agent User @relation(fields: [agentId], references: [id])
+  agent     User  @relation(fields: [agentId], references: [id])
+  blockedBy User? @relation("BlockedBy", fields: [blockedById], references: [id])
 
   @@map("agent_balances")
 }

--- a/backend/scripts/seed-comprehensive-data.ts
+++ b/backend/scripts/seed-comprehensive-data.ts
@@ -14,6 +14,10 @@ async function main() {
   await prisma.workflow.deleteMany();
   await prisma.webhookLog.deleteMany();
   await prisma.webhookConfig.deleteMany();
+  await prisma.agentAgingBucket.deleteMany();
+  await prisma.agentDeposit.deleteMany();
+  await prisma.agentCollection.deleteMany();
+  await prisma.agentBalance.deleteMany();
   await prisma.delivery.deleteMany();
   await prisma.orderItem.deleteMany();
   await prisma.orderHistory.deleteMany();

--- a/backend/src/__tests__/unit/assignmentService.test.ts
+++ b/backend/src/__tests__/unit/assignmentService.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import assignmentService from '../../services/assignmentService';
+import prisma from '../../utils/prisma';
+
+// Mock prisma
+jest.mock('../../utils/prisma', () => ({
+    __esModule: true,
+    default: {
+        user: {
+            findMany: jest.fn(),
+        },
+    },
+}));
+
+describe('AssignmentService', () => {
+    const mockPrisma = prisma as any;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('getUsersByRole', () => {
+        it('should filter out blocked agents', async () => {
+            const mockUsers = [
+                { id: 1, firstName: 'Available Agent', role: 'delivery_agent', isActive: true, isAvailable: true },
+            ];
+
+            mockPrisma.user.findMany.mockResolvedValue(mockUsers);
+
+            const result = await assignmentService.getUsersByRole('delivery_agent');
+
+            expect(mockPrisma.user.findMany).toHaveBeenCalledWith(expect.objectContaining({
+                where: expect.objectContaining({
+                    role: 'delivery_agent',
+                    balance: {
+                        OR: [
+                            { isBlocked: false },
+                            { isBlocked: null }
+                        ]
+                    }
+                })
+            }));
+            expect(result).toEqual(mockUsers);
+        });
+
+        it('should NOT apply blocking filter for other roles', async () => {
+            const mockUsers = [
+                { id: 10, firstName: 'Sales Rep', role: 'sales_rep', isActive: true, isAvailable: true },
+            ];
+
+            mockPrisma.user.findMany.mockResolvedValue(mockUsers);
+
+            await assignmentService.getUsersByRole('sales_rep');
+
+            expect(mockPrisma.user.findMany).toHaveBeenCalledWith(expect.objectContaining({
+                where: {
+                    role: 'sales_rep',
+                    isActive: true,
+                    isAvailable: true
+                }
+            }));
+        });
+    });
+});

--- a/backend/src/routes/agentReconciliationRoutes.ts
+++ b/backend/src/routes/agentReconciliationRoutes.ts
@@ -114,4 +114,29 @@ router.get('/aging/export',
     agentReconciliationController.exportAgingReport
 );
 
+// Agent Blocking
+router.post('/agents/:id/block',
+    requireRole('super_admin', 'admin', 'manager'),
+    [
+        param('id').isInt().toInt(),
+        body('reason').notEmpty().withMessage('Reason is required'),
+        validate
+    ],
+    agentReconciliationController.blockAgent
+);
+
+router.post('/agents/:id/unblock',
+    requireRole('super_admin', 'admin', 'manager'),
+    [
+        param('id').isInt().toInt(),
+        validate
+    ],
+    agentReconciliationController.unblockAgent
+);
+
+router.get('/agents/blocked',
+    requireRole('super_admin', 'admin', 'manager', 'accountant'),
+    agentReconciliationController.getBlockedAgents
+);
+
 export default router;

--- a/backend/src/services/assignmentService.ts
+++ b/backend/src/services/assignmentService.ts
@@ -160,6 +160,15 @@ export class AssignmentService {
         role: role as any,
         isActive: true,
         isAvailable: true,
+        // If it's a delivery agent, check if they are blocked in AgentBalance
+        ...(role === 'delivery_agent' ? {
+          balance: {
+            OR: [
+              { isBlocked: false },
+              { isBlocked: null } // Handle if balance doesn't exist yet
+            ]
+          }
+        } : {}),
         ...additionalFilters
       },
       orderBy: { firstName: 'asc' }

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -69,3 +69,28 @@ export async function notifyDeliveryScheduled(
     { orderId, orderNumber, scheduledTime }
   );
 }
+
+export async function notifyAgentBlocked(
+  userId: string,
+  reason: string
+) {
+  return createNotification(
+    userId,
+    'agent_blocked',
+    'Account Blocked',
+    `Your account has been blocked: ${reason}`,
+    { reason }
+  );
+}
+
+export async function notifyAgentUnblocked(
+  userId: string
+) {
+  return createNotification(
+    userId,
+    'agent_unblocked',
+    'Account Unblocked',
+    'Your account has been unblocked. You can now receive new deliveries.',
+    {}
+  );
+}


### PR DESCRIPTION
Implemented Agent Blocking for Discrepancies (MAN-12).

Changes include:
- Database schema updates for AgentBalance to track isBlocked, reason, and audit info.
- Manual block/unblock logic in AgentReconciliationService.
- Automatic blocking for overdue agents (4+ days) in AgingService.
- Daily 10:00 AM cron job for auto-blocking checks.
- Order assignment filtering to prevent assigning tasks to blocked agents.
- Real-time and in-app notifications for agents and managers.

Verified with unit tests for Reconciliation, Aging, and Assignment services.