### PR TITLE
fix: Order Status Distribution date range filter

### DIFF
--- a/frontend/src/config/dashboards/adminConfig.ts
+++ b/frontend/src/config/dashboards/adminConfig.ts
@@ -102,7 +102,7 @@ export const adminDashboardConfig: DashboardConfig = {
       title: 'Order Status Distribution',
       gridPosition: { row: 1, col: 3, colSpan: 1 },
       height: 350,
-      dataSource: 'conversionFunnel',
+      dataSource: 'ordersByStatus',
       config: {
         nameKey: 'status',
         valueKey: 'count',
@@ -128,6 +128,7 @@ export const adminDashboardConfig: DashboardConfig = {
     'fetchDashboardMetrics',
     'fetchSalesTrends',
     'fetchConversionFunnel',
+    'fetchOrdersByStatus',
     'fetchCustomerInsights',
   ],
 };


### PR DESCRIPTION
## Summary
Fixes the Order Status Distribution donut chart to properly respect date range filters on the Admin Dashboard.

## Changes
- Changed chart dataSource from `conversionFunnel` to `ordersByStatus`
- Added `fetchOrdersByStatus` to dataFetchers array
- Chart now calls correct backend endpoint (`/api/analytics/status-distribution`) with date parameters

## Testing Checklist
- [ ] Verify chart updates when changing date range filter
- [ ] Test MTD (This Month) default filter
- [ ] Test "Last 7 Days" preset
- [ ] Test custom date ranges
- [ ] Check DevTools Network tab shows correct API calls to `/api/analytics/status-distribution?startDate=...&endDate=...`
- [ ] Verify chart displays accurate order counts for selected period

## Technical Details
- **Root Cause:** Chart was using `conversionFunnel` data source instead of `ordersByStatus`
- **Solution:** Simple configuration fix - no backend changes required
- **Backend:** Endpoint already has full date filtering support

## Impact
- Users can now filter order status distribution by any date range
- Default MTD filter now works correctly
- Improves dashboard accuracy and usability

🤖 Generated with Claude Code