### PR TITLE
fix: remove duplicate region in order address display

### DIFF
--- a/frontend/src/pages/OrderDetails.tsx
+++ b/frontend/src/pages/OrderDetails.tsx
@@ -241,7 +241,7 @@ export const OrderDetails: React.FC = () => {
                       <p className="text-sm text-gray-500">Shipping Address</p>
                       <p className="font-medium text-gray-900">
                         {order.shippingAddress.street}<br />
-                        {order.shippingAddress.area}, {order.shippingAddress.state}
+                        {order.shippingAddress.state}
                       </p>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- Order details showed region name twice (e.g. "Greater Accra, Greater Accra") because `deliveryArea` and `deliveryState` were set to the same value for checkout form orders
- Display now shows only the state/region once

## Test plan
- [x] Frontend builds successfully
- [ ] Verify order details page shows region only once

🤖 Generated with [Claude Code](https://claude.com/claude-code)