### PR TITLE
fix: financial module aging data + UI fixes

### DIFF
--- a/backend/src/controllers/financialController.ts
+++ b/backend/src/controllers/financialController.ts
@@ -354,3 +354,108 @@ export const getFinancialHealth = async (_req: AuthRequest, res: Response): Prom
     res.status(500).json({ message: 'Failed to fetch financial health' });
   }
 };
+
+/**
+ * POST /api/financial/refresh-aging
+ * Admin-only endpoint to manually trigger aging bucket refresh
+ * Use when aging data is stale or after bulk reconciliation
+ */
+export const refreshAgingBuckets = async (_req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    await agingService.refreshAll();
+    res.json({ message: 'Aging buckets refreshed successfully' });
+  } catch (error) {
+    logger.error('Failed to refresh aging buckets', { error });
+    res.status(500).json({ message: 'Failed to refresh aging buckets' });
+  }
+};
+
+/**
+ * POST /api/financial/backfill-collections
+ * Admin-only endpoint to create missing agent_collection records
+ * for delivered orders that have no collection tracking
+ */
+export const backfillMissingCollections = async (_req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    // Find all delivered orders without agent_collections
+    const orphanedOrders = await prisma.$queryRaw<any[]>`
+      SELECT o.id, o.delivery_agent_id, o.total_amount, o.created_at
+      FROM orders o
+      WHERE o.status = 'delivered'
+        AND o.deleted_at IS NULL
+        AND o.delivery_agent_id IS NOT NULL
+        AND o.id NOT IN (SELECT order_id FROM agent_collections)
+      ORDER BY o.created_at ASC
+    `;
+
+    if (orphanedOrders.length === 0) {
+      res.json({ message: 'No orphaned orders found', created: 0 });
+      return;
+    }
+
+    // Group by agent for balance updates
+    const byAgent = new Map<number, { orders: any[], total: number }>();
+    for (const order of orphanedOrders) {
+      const agentId = order.delivery_agent_id;
+      if (!byAgent.has(agentId)) {
+        byAgent.set(agentId, { orders: [], total: 0 });
+      }
+      const group = byAgent.get(agentId)!;
+      group.orders.push(order);
+      group.total += parseFloat(order.total_amount);
+    }
+
+    await prisma.$transaction(async (tx) => {
+      const extTx = tx as any;
+
+      for (const [agentId, { orders, total }] of byAgent) {
+        // Create draft collections for each order
+        for (const order of orders) {
+          await extTx.agentCollection.create({
+            data: {
+              orderId: order.id,
+              agentId,
+              amount: parseFloat(order.total_amount),
+              status: 'draft',
+              collectionDate: order.created_at,
+            },
+          });
+        }
+
+        // Update agent balance
+        await extTx.agentBalance.upsert({
+          where: { agentId },
+          create: {
+            agentId,
+            totalCollected: total,
+            totalDeposited: 0,
+            currentBalance: total,
+          },
+          update: {
+            totalCollected: { increment: total },
+            currentBalance: { increment: total },
+          },
+        });
+      }
+    });
+
+    // Refresh aging buckets after backfill
+    await agingService.refreshAll();
+
+    const summary = Array.from(byAgent.entries()).map(([agentId, { orders, total }]) => ({
+      agentId,
+      ordersBackfilled: orders.length,
+      totalAmount: total,
+    }));
+
+    logger.info('Backfilled missing agent collections', { summary });
+    res.json({
+      message: `Backfilled ${orphanedOrders.length} missing collections`,
+      created: orphanedOrders.length,
+      summary,
+    });
+  } catch (error) {
+    logger.error('Failed to backfill missing collections', { error });
+    res.status(500).json({ message: 'Failed to backfill missing collections' });
+  }
+};

--- a/backend/src/routes/financialRoutes.ts
+++ b/backend/src/routes/financialRoutes.ts
@@ -44,4 +44,8 @@ router.get('/agents/settlement/:agentId', requireResourcePermission('financial',
 // Financial health (admin/super_admin only)
 router.get('/health', requireRole('admin', 'super_admin'), financialController.getFinancialHealth);
 
+// Admin maintenance endpoints
+router.post('/refresh-aging', requireRole('admin', 'super_admin'), financialController.refreshAgingBuckets);
+router.post('/backfill-collections', requireRole('admin', 'super_admin'), financialController.backfillMissingCollections);
+
 export default router;

--- a/backend/src/services/agentReconciliationService.ts
+++ b/backend/src/services/agentReconciliationService.ts
@@ -60,9 +60,12 @@ export class AgentReconciliationService {
      * Internal version that handles state transitions and GL integration
      */
     async verifyCollection(collectionId: number, verifierId: number) {
-        return await prisma.$transaction(async (tx) => {
+        const result = await prisma.$transaction(async (tx) => {
             return await this.verifyCollectionInternal(tx, collectionId, verifierId);
         }, TRANSACTION_CONFIG);
+        // Emit AFTER transaction commits so aging refresh reads committed data
+        appEvents.emit(AppEvent.AGENT_COLLECTION_RECONCILED);
+        return result;
     }
 
     /**
@@ -84,9 +87,12 @@ export class AgentReconciliationService {
      * Only managers/admins can perform this action
      */
     async approveCollection(collectionId: number, approverId: number) {
-        return await prisma.$transaction(async (tx) => {
+        const result = await prisma.$transaction(async (tx) => {
             return await this.verifyCollectionInternal(tx, collectionId, approverId);
         }, TRANSACTION_CONFIG);
+        // Emit AFTER transaction commits so aging refresh reads committed data
+        appEvents.emit(AppEvent.AGENT_COLLECTION_RECONCILED);
+        return result;
     }
 
     async getOrCreateBalance(agentId: number, tx?: any): Promise<any> {
@@ -230,7 +236,7 @@ export class AgentReconciliationService {
      * Verify an agent deposit
      */
     async verifyDeposit(depositId: number, verifierId: number): Promise<any> {
-        return await prisma.$transaction(async (tx) => {
+        const result = await prisma.$transaction(async (tx) => {
             const extTx = tx as any;
             const deposit = await extTx.agentDeposit.findUnique({
                 where: { id: depositId },
@@ -295,11 +301,11 @@ export class AgentReconciliationService {
 
             logger.info(`Deposit ${depositId} verified by user ${verifierId} `);
 
-            // Trigger proactive aging refresh via event bus
-            appEvents.emit(AppEvent.AGENT_COLLECTION_RECONCILED);
-
             return updated;
         }, TRANSACTION_CONFIG);
+        // Emit AFTER transaction commits so aging refresh reads committed data
+        appEvents.emit(AppEvent.AGENT_COLLECTION_RECONCILED);
+        return result;
     }
 
     /**
@@ -319,7 +325,7 @@ export class AgentReconciliationService {
             throw new AppError('Cannot verify more than 50 deposits at once', 400);
         }
 
-        return await prisma.$transaction(async (tx) => {
+        const result = await prisma.$transaction(async (tx) => {
             const extTx = tx as any;
             let totalAmount = new Prisma.Decimal(0);
 
@@ -420,14 +426,14 @@ export class AgentReconciliationService {
                 totalAmount: totalAmount.toString()
             });
 
-            // Trigger proactive aging refresh (non-blocking)
-            appEvents.emit(AppEvent.AGENT_COLLECTION_RECONCILED);
-
             return {
                 verified: deposits.length,
                 totalAmount: totalAmount.toNumber()
             };
         }, TRANSACTION_CONFIG);
+        // Emit AFTER transaction commits so aging refresh reads committed data
+        appEvents.emit(AppEvent.AGENT_COLLECTION_RECONCILED);
+        return result;
     }
 
     /**
@@ -465,7 +471,7 @@ export class AgentReconciliationService {
      * Atomic: rolls back entirely if any verification fails
      */
     async bulkVerifyCollections(collectionIds: number[], verifierId: number) {
-        return await prisma.$transaction(async (tx) => {
+        const results = await prisma.$transaction(async (tx) => {
             const extTx = tx as any;
             const results = [];
             for (const id of collectionIds) {
@@ -475,6 +481,9 @@ export class AgentReconciliationService {
             }
             return results;
         }, TRANSACTION_CONFIG);
+        // Emit AFTER transaction commits so aging refresh reads committed data
+        appEvents.emit(AppEvent.AGENT_COLLECTION_RECONCILED);
+        return results;
     }
 
     /**
@@ -549,8 +558,8 @@ export class AgentReconciliationService {
 
         logger.info(`Collection ${collectionId} reconciled by user ${verifierId} `);
 
-        // Trigger proactive aging refresh (non-blocking)
-        appEvents.emit(AppEvent.AGENT_COLLECTION_RECONCILED);
+        // Note: aging refresh event is emitted by the caller AFTER the transaction commits
+        // to avoid race conditions where refreshAll() reads uncommitted data
 
         return updated;
     }


### PR DESCRIPTION
## Summary
- **Fix stale aging buckets after reconciliation** — moved event emission outside `$transaction` to prevent race condition where aging refresh reads uncommitted data. VDL showed GHS 72,425 outstanding despite all collections being reconciled.
- **Add admin endpoints** for manual aging refresh (`POST /api/financial/refresh-aging`) and backfilling missing agent collections (`POST /api/financial/backfill-collections`)
- **Fix package name wrapping** and badge overflow on narrow screens in PackageSelector
- **Collapse packages/upsells by default** in checkout form editor

## Test plan
- [ ] Deploy to staging and verify aging buckets refresh correctly after reconciliation
- [ ] Call `POST /api/financial/refresh-aging` on production to fix VDL's stale data
- [ ] Call `POST /api/financial/backfill-collections` to create 28 missing VDL collection records
- [ ] Verify financial dashboard KPIs show accurate numbers
- [ ] Unblock VDL agent after data correction

🤖 Generated with [Claude Code](https://claude.com/claude-code)