### PR TITLE
feat: manual agent blocking with admin notifications

### DIFF
--- a/backend/src/__tests__/unit/agingService.test.ts
+++ b/backend/src/__tests__/unit/agingService.test.ts
@@ -145,6 +145,7 @@ describe('AgingService', () => {
             mockPrisma.agentAgingBucket.findMany.mockResolvedValue(mockBuckets);
             mockPrisma.agentBalance = {
                 count: jest.fn().mockResolvedValue(1),
+                findMany: jest.fn().mockResolvedValue([{ agentId: 1, isBlocked: false }]),
             } as any;
             mockPrisma.account = {
                 findFirst: jest.fn().mockResolvedValue({ currentBalance: new Prisma.Decimal(10000) }),
@@ -153,7 +154,7 @@ describe('AgingService', () => {
             const result = await agingService.getAgingReport();
 
             expect(result.summary).toBeDefined();
-            expect(result.buckets).toEqual(mockBuckets);
+            expect(result.buckets[0].isBlocked).toBe(false);
             expect(result.summary.totalOutstandingAmount).toBe(10000);
             expect(result.summary.bucketTotals.bucket_8_plus).toBe(4000);
             expect(mockPrisma.agentAgingBucket.findMany).toHaveBeenCalledWith({
@@ -165,24 +166,20 @@ describe('AgingService', () => {
         });
     });
 
-    describe('autoBlockOverdueAgents', () => {
-        it('should block agents with overdue buckets', async () => {
+    describe('getOverdueAgents', () => {
+        it('should return agents with overdue buckets', async () => {
             const mockBuckets = [
-                { agentId: 1, bucket_4_7: new Prisma.Decimal(500), bucket_8_plus: new Prisma.Decimal(0) },
-                { agentId: 2, bucket_4_7: new Prisma.Decimal(0), bucket_8_plus: new Prisma.Decimal(1000) },
+                { agentId: 1, totalBalance: new Prisma.Decimal(500), bucket_4_7: new Prisma.Decimal(500), bucket_8_plus: new Prisma.Decimal(0), agent: { id: 1, firstName: 'Agent', lastName: 'One' } },
+                { agentId: 2, totalBalance: new Prisma.Decimal(1000), bucket_4_7: new Prisma.Decimal(0), bucket_8_plus: new Prisma.Decimal(1000), agent: { id: 2, firstName: 'Agent', lastName: 'Two' } },
             ];
 
             mockPrisma.agentAgingBucket.findMany.mockResolvedValue(mockBuckets);
 
-            // Get the mocked service instance (it was mocked at the top)
-            const agentReconciliationService = (require('../../services/agentReconciliationService')).default;
-            agentReconciliationService.getAgentBalance.mockResolvedValue({ isBlocked: false });
-            agentReconciliationService.blockAgent.mockResolvedValue({});
+            const result = await agingService.getOverdueAgents();
 
-            const result = await agingService.autoBlockOverdueAgents(1);
-
-            expect(result).toBe(2); // Agent 1 and 2 should be blocked
-            expect(agentReconciliationService.blockAgent).toHaveBeenCalledTimes(2);
+            expect(result).toHaveLength(2);
+            expect(result[0]).toEqual({ agentId: 1, agentName: 'Agent One', totalBalance: 500, warningAmount: 500, criticalAmount: 0 });
+            expect(result[1]).toEqual({ agentId: 2, agentName: 'Agent Two', totalBalance: 1000, warningAmount: 0, criticalAmount: 1000 });
         });
     });
 });

--- a/backend/src/queues/agingQueue.ts
+++ b/backend/src/queues/agingQueue.ts
@@ -1,5 +1,6 @@
 import Bull from 'bull';
 import agingService from '../services/agingService';
+import { notifyAdminsOverdueCollections } from '../services/notificationService';
 import logger from '../utils/logger';
 
 const redisConfig = {
@@ -38,16 +39,19 @@ agingQueue.process('refresh-buckets', async () => {
     }
 });
 
-// Process the auto-block job
-agingQueue.process('auto-block-overdue', async () => {
-    logger.info('Processing auto-block overdue agents job...');
+// Process the overdue collections notification job
+agingQueue.process('notify-overdue-collections', async () => {
+    logger.info('Processing overdue collections notification job...');
     try {
-        // Use system/admin user ID for auto-blocking (usually user ID 1 or a constant)
-        const SYSTEM_USER_ID = 1;
-        const blockedCount = await agingService.autoBlockOverdueAgents(SYSTEM_USER_ID);
-        logger.info(`Auto-block job completed. Blocked ${blockedCount} agents.`);
+        const overdueAgents = await agingService.getOverdueAgents();
+        if (overdueAgents.length > 0) {
+            await notifyAdminsOverdueCollections(overdueAgents);
+            logger.info(`Notified admins about ${overdueAgents.length} agents with overdue collections.`);
+        } else {
+            logger.info('No overdue collections found.');
+        }
     } catch (error: any) {
-        logger.error('Auto-block job failed:', error.message);
+        logger.error('Overdue notification job failed:', error.message);
         throw error;
     }
 });
@@ -69,14 +73,14 @@ export const setupAgingCron = async () => {
         }
     });
 
-    // Add daily auto-block job at 10:00 AM
-    await agingQueue.add('auto-block-overdue', {}, {
+    // Add daily overdue notification job at 10:00 AM
+    await agingQueue.add('notify-overdue-collections', {}, {
         repeat: {
             cron: '0 10 * * *'
         }
     });
 
-    logger.info('Agent aging cron jobs scheduled (6:00 AM refresh, 10:00 AM auto-block).');
+    logger.info('Agent aging cron jobs scheduled (6:00 AM refresh, 10:00 AM overdue notifications).');
 };
 
 agingQueue.on('failed', (job: Bull.Job | undefined, err: Error) => {

--- a/backend/src/services/agingService.ts
+++ b/backend/src/services/agingService.ts
@@ -184,11 +184,26 @@ export class AgingService {
       }
     });
 
+    // Enrich with blocked status from agent_balances
+    const agentIds = buckets.map((b: any) => b.agentId);
+    const balances = agentIds.length > 0
+      ? await (prisma as any).agentBalance.findMany({
+          where: { agentId: { in: agentIds } },
+          select: { agentId: true, isBlocked: true }
+        })
+      : [];
+    const blockedMap = new Map(balances.map((b: any) => [b.agentId, b.isBlocked]));
+
+    const enrichedBuckets = buckets.map((b: any) => ({
+      ...b,
+      isBlocked: blockedMap.get(b.agentId) || false,
+    }));
+
     const summary = await this.getAgingSummary(buckets);
 
     return {
       summary,
-      buckets
+      buckets: enrichedBuckets
     };
   }
 
@@ -272,12 +287,10 @@ export class AgingService {
     };
   }
   /**
-   * Automatically blocks agents who have collections in the 4-7 day or 8+ day buckets
+   * Get agents with overdue collections (4-7 day or 8+ day buckets)
+   * Used by the notification job to alert admins
    */
-  async autoBlockOverdueAgents(managerUserId: number): Promise<number> {
-    logger.info('Checking for overdue agents to auto-block...');
-
-    // Find all buckets with values in overdue columns
+  async getOverdueAgents(): Promise<{ agentId: number; agentName: string; totalBalance: number; warningAmount: number; criticalAmount: number }[]> {
     const overdueBuckets = await (prisma as any).agentAgingBucket.findMany({
       where: {
         OR: [
@@ -292,30 +305,13 @@ export class AgingService {
       }
     });
 
-    logger.info(`Found ${overdueBuckets.length} agents with overdue collections.`);
-
-    let blockedCount = 0;
-    const agentReconciliationService = (await import('./agentReconciliationService')).default;
-
-    for (const bucket of overdueBuckets) {
-      try {
-        // Double check they aren't already blocked to avoid redundant updates/notifications
-        const balance = await agentReconciliationService.getAgentBalance(bucket.agentId);
-        if (balance && !balance.isBlocked) {
-          await agentReconciliationService.blockAgent(
-            bucket.agentId,
-            managerUserId,
-            'Automatic block: Overdue collection balance (4+ days)'
-          );
-          blockedCount++;
-        }
-      } catch (error) {
-        logger.error(`Failed to auto-block agent ${bucket.agentId}:`, error);
-      }
-    }
-
-    logger.info(`Auto-block cycle completed. Blocked ${blockedCount} agents.`);
-    return blockedCount;
+    return overdueBuckets.map((bucket: any) => ({
+      agentId: bucket.agentId,
+      agentName: `${bucket.agent.firstName} ${bucket.agent.lastName}`,
+      totalBalance: parseFloat(bucket.totalBalance.toString()),
+      warningAmount: parseFloat(bucket.bucket_4_7.toString()),
+      criticalAmount: parseFloat(bucket.bucket_8_plus.toString()),
+    }));
   }
 }
 

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -70,6 +70,34 @@ export async function notifyDeliveryScheduled(
   );
 }
 
+export async function notifyAdminsOverdueCollections(
+  agents: { agentId: number; agentName: string; totalBalance: number; warningAmount: number; criticalAmount: number }[]
+) {
+  if (agents.length === 0) return;
+
+  // Find all admin and super_admin users
+  const admins = await prisma.user.findMany({
+    where: { role: { in: ['admin', 'super_admin'] }, isActive: true },
+    select: { id: true }
+  });
+
+  const agentSummary = agents
+    .map(a => `${a.agentName}: GHS ${a.totalBalance.toFixed(2)} (${a.criticalAmount > 0 ? '8+ days' : '4-7 days'})`)
+    .join(', ');
+
+  const totalOverdue = agents.reduce((sum, a) => sum + a.totalBalance, 0);
+
+  for (const admin of admins) {
+    await createNotification(
+      admin.id.toString(),
+      'overdue_collections',
+      'Overdue Agent Collections',
+      `${agents.length} agent(s) have overdue collections totaling GHS ${totalOverdue.toFixed(2)}: ${agentSummary}`,
+      { agents, totalOverdue }
+    );
+  }
+}
+
 export async function notifyAgentBlocked(
   userId: string,
   reason: string

--- a/frontend/src/components/financial/AgentAgingTab.tsx
+++ b/frontend/src/components/financial/AgentAgingTab.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useMemo } from 'react';
 import { useFinancialStore } from '../../stores/financialStore';
 import { Card } from '../ui/Card';
 import { formatCurrency } from '../../utils/format';
-import { Download, AlertCircle, Clock, Users, ShieldAlert, BarChart3, Filter, Mail, Ban, Eye, ChevronUp, ChevronDown, Info } from 'lucide-react';
+import { Download, AlertCircle, Clock, Users, ShieldAlert, BarChart3, Filter, Mail, Ban, ShieldCheck, Eye, ChevronUp, ChevronDown, Info } from 'lucide-react';
 import { Tooltip as UITooltip } from '../ui/Tooltip';
 import { financialService } from '../../services/financial.service';
 import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from 'recharts';
@@ -24,6 +24,26 @@ export const AgentAgingTab: React.FC = () => {
     useEffect(() => {
         fetchAgentAging();
     }, []);
+
+    const [blockingAgentId, setBlockingAgentId] = useState<number | null>(null);
+
+    const handleToggleBlock = async (agentId: number, agentName: string, isBlocked: boolean) => {
+        setBlockingAgentId(agentId);
+        try {
+            if (isBlocked) {
+                await financialService.unblockAgent(agentId);
+                toast.success(`${agentName} unblocked`);
+            } else {
+                await financialService.blockAgent(agentId, 'Overdue collection balance');
+                toast.success(`${agentName} blocked from deliveries`);
+            }
+            fetchAgentAging();
+        } catch (error: any) {
+            toast.error(error?.response?.data?.message || `Failed to ${isBlocked ? 'unblock' : 'block'} agent`);
+        } finally {
+            setBlockingAgentId(null);
+        }
+    };
 
     const handleExport = async () => {
         try {
@@ -132,7 +152,7 @@ export const AgentAgingTab: React.FC = () => {
                     <div className="flex items-center justify-between mb-2">
                         <span className="text-xs font-bold text-gray-500 uppercase tracking-wider flex items-center gap-1">
                             Critical (8+ Days)
-                            <UITooltip content="Collections held beyond 8 days — agents are at risk of being auto-blocked from new deliveries" position="bottom">
+                            <UITooltip content="Collections held beyond 8 days — consider blocking agents from new deliveries" position="bottom">
                                 <Info className="w-3.5 h-3.5 text-gray-400 hover:text-gray-600 cursor-help" />
                             </UITooltip>
                         </span>
@@ -329,12 +349,21 @@ export const AgentAgingTab: React.FC = () => {
                                                         <Eye className="w-3.5 h-3.5" />
                                                     </Link>
                                                     <button
-                                                        title="Block Agent (Coming Soon)"
-                                                        aria-label={`Block agent ${entry.agent.firstName}`}
-                                                        className="p-1.5 text-gray-300 cursor-not-allowed rounded"
-                                                        disabled
+                                                        title={entry.isBlocked ? 'Unblock Agent' : 'Block Agent'}
+                                                        aria-label={`${entry.isBlocked ? 'Unblock' : 'Block'} agent ${entry.agent.firstName}`}
+                                                        className={cn(
+                                                            "p-1.5 rounded transition-colors",
+                                                            entry.isBlocked
+                                                                ? "text-red-600 bg-red-50 hover:bg-red-100"
+                                                                : "text-gray-400 hover:text-red-600 hover:bg-red-50"
+                                                        )}
+                                                        disabled={blockingAgentId === entry.agent.id}
+                                                        onClick={() => handleToggleBlock(entry.agent.id, `${entry.agent.firstName} ${entry.agent.lastName}`, entry.isBlocked)}
                                                     >
-                                                        <Ban className="w-3.5 h-3.5" />
+                                                        {entry.isBlocked
+                                                            ? <ShieldCheck className="w-3.5 h-3.5" />
+                                                            : <Ban className="w-3.5 h-3.5" />
+                                                        }
                                                     </button>
                                                 </div>
                                             </td>

--- a/frontend/src/pages/financial/AgentCollections.tsx
+++ b/frontend/src/pages/financial/AgentCollections.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
-import { Users, AlertTriangle, Clock, BarChart3, Download, Filter, Mail, Eye, ChevronUp, ChevronDown, Info } from 'lucide-react';
+import { Users, AlertTriangle, Clock, BarChart3, Download, Filter, Mail, Eye, ChevronUp, ChevronDown, Info, Ban, ShieldCheck } from 'lucide-react';
 import { useFinancialStore } from '../../stores/financialStore';
 import { Card } from '../../components/ui/Card';
 import { Tooltip as UITooltip } from '../../components/ui/Tooltip';
@@ -22,6 +22,25 @@ export const AgentCollections: React.FC = () => {
 
   // Selection state for reconciliation
   const [selectedAgent, setSelectedAgent] = useState<{ id: number; name: string } | null>(null);
+  const [blockingAgentId, setBlockingAgentId] = useState<number | null>(null);
+
+  const handleToggleBlock = async (agentId: number, agentName: string, isBlocked: boolean) => {
+    setBlockingAgentId(agentId);
+    try {
+      if (isBlocked) {
+        await financialService.unblockAgent(agentId);
+        toast.success(`${agentName} unblocked`);
+      } else {
+        await financialService.blockAgent(agentId, 'Overdue collection balance');
+        toast.success(`${agentName} blocked from deliveries`);
+      }
+      fetchAgentAging();
+    } catch (error: any) {
+      toast.error(error?.response?.data?.message || `Failed to ${isBlocked ? 'unblock' : 'block'} agent`);
+    } finally {
+      setBlockingAgentId(null);
+    }
+  };
 
   useEffect(() => {
     fetchAgentAging();
@@ -144,7 +163,7 @@ export const AgentCollections: React.FC = () => {
             <div className="flex items-start justify-between mb-2">
               <span className="text-xs font-bold text-gray-500 uppercase tracking-wider flex items-center gap-1">
                 Critical (8+ Days)
-                <UITooltip content="Collections held beyond 8 days — agents at risk of being blocked from new deliveries" position="bottom">
+                <UITooltip content="Collections held beyond 8 days — consider blocking agents from new deliveries" position="bottom">
                   <Info className="w-3 h-3 text-gray-400 hover:text-gray-600 cursor-help" />
                 </UITooltip>
               </span>
@@ -323,6 +342,25 @@ export const AgentCollections: React.FC = () => {
                           >
                             <Eye className="w-4 h-4 mr-1 text-gray-400" />
                             Verify Collections
+                          </button>
+                          <button
+                            title={bucket.isBlocked ? 'Unblock Agent' : 'Block Agent'}
+                            className={`p-1.5 rounded transition-colors ${
+                              bucket.isBlocked
+                                ? 'text-red-600 bg-red-50 hover:bg-red-100'
+                                : 'text-gray-400 hover:text-red-600 hover:bg-red-50'
+                            }`}
+                            disabled={blockingAgentId === bucket.agentId}
+                            onClick={() => handleToggleBlock(
+                              bucket.agentId,
+                              `${bucket.agent.firstName} ${bucket.agent.lastName}`,
+                              bucket.isBlocked
+                            )}
+                          >
+                            {bucket.isBlocked
+                              ? <ShieldCheck className="w-4 h-4" />
+                              : <Ban className="w-4 h-4" />
+                            }
                           </button>
                         </div>
                       </td>

--- a/frontend/src/services/financial.service.ts
+++ b/frontend/src/services/financial.service.ts
@@ -130,6 +130,7 @@ export interface AgentAgingBucket {
   bucket_2_3: number;
   bucket_4_7: number;
   bucket_8_plus: number;
+  isBlocked: boolean;
   updatedAt: string;
 }
 
@@ -540,5 +541,13 @@ export const financialService = {
 
   async rejectDeposit(depositId: number, notes: string): Promise<void> {
     await apiClient.post(`/api/agent-reconciliation/deposits/${depositId}/reject`, { notes });
-  }
+  },
+
+  async blockAgent(agentId: number, reason: string): Promise<void> {
+    await apiClient.post(`/api/agent-reconciliation/agents/${agentId}/block`, { reason });
+  },
+
+  async unblockAgent(agentId: number): Promise<void> {
+    await apiClient.post(`/api/agent-reconciliation/agents/${agentId}/unblock`);
+  },
 };


### PR DESCRIPTION
## Summary
- Replaced automatic daily agent blocking with admin notification system for overdue collections
- Added manual Block/Unblock toggle button in the Agent Collections table Actions column
- Enriched aging report API with `isBlocked` status per agent for UI display

## Test plan
- [x] Block/Unblock button tested locally — toggles agent blocked status with toast feedback
- [x] Block/Unblock API endpoints verified via curl (block with reason, unblock clears)
- [x] Overdue notification system tested — creates admin notifications with agent details
- [x] Aging service unit tests pass (5/5)
- [x] Backend builds clean, lint passes
- [x] Frontend build successful with updated types

🤖 Generated with [Claude Code](https://claude.com/claude-code)