### PR TITLE
fix: resolve financial module data accuracy issues

### DIFF
--- a/backend/src/controllers/financialController.ts
+++ b/backend/src/controllers/financialController.ts
@@ -459,3 +459,54 @@ export const backfillMissingCollections = async (_req: AuthRequest, res: Respons
     res.status(500).json({ message: 'Failed to backfill missing collections' });
   }
 };
+
+/**
+ * POST /api/financial/backfill-delivery-dates
+ * Admin-only endpoint to set deliveryDate on delivered orders that are missing it.
+ * Uses orderHistory (status = 'delivered') createdAt, falling back to order.updatedAt.
+ */
+export const backfillDeliveryDates = async (_req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const orders = await prisma.order.findMany({
+      where: {
+        status: 'delivered',
+        deliveryDate: null,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        updatedAt: true,
+        orderHistory: {
+          where: { status: 'delivered' },
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+          select: { createdAt: true },
+        },
+      },
+    });
+
+    if (orders.length === 0) {
+      res.json({ message: 'No orders with missing deliveryDate found', updated: 0 });
+      return;
+    }
+
+    let updated = 0;
+    for (const order of orders) {
+      const deliveryDate = order.orderHistory[0]?.createdAt || order.updatedAt;
+      await prisma.order.update({
+        where: { id: order.id },
+        data: { deliveryDate },
+      });
+      updated++;
+    }
+
+    logger.info(`Backfilled deliveryDate for ${updated} orders`);
+    res.json({
+      message: `Backfilled deliveryDate for ${updated} orders`,
+      updated,
+    });
+  } catch (error) {
+    logger.error('Failed to backfill delivery dates', { error });
+    res.status(500).json({ message: 'Failed to backfill delivery dates' });
+  }
+};

--- a/backend/src/routes/financialRoutes.ts
+++ b/backend/src/routes/financialRoutes.ts
@@ -47,5 +47,6 @@ router.get('/health', requireRole('admin', 'super_admin'), financialController.g
 // Admin maintenance endpoints
 router.post('/refresh-aging', requireRole('admin', 'super_admin'), financialController.refreshAgingBuckets);
 router.post('/backfill-collections', requireRole('admin', 'super_admin'), financialController.backfillMissingCollections);
+router.post('/backfill-delivery-dates', requireRole('admin', 'super_admin'), financialController.backfillDeliveryDates);
 
 export default router;

--- a/backend/src/services/deliveryService.ts
+++ b/backend/src/services/deliveryService.ts
@@ -306,6 +306,7 @@ export class DeliveryService {
         where: { id: delivery.orderId },
         data: {
           status: 'delivered',
+          deliveryDate: new Date(),
           paymentStatus: 'collected',
           orderHistory: {
             create: {

--- a/backend/src/services/financialService.ts
+++ b/backend/src/services/financialService.ts
@@ -1082,7 +1082,7 @@ export class FinancialService {
       totalShippingCost += order.shippingCost;
       totalDiscount += order.discount;
 
-      const dateStr = order.deliveryDate ? order.deliveryDate.toISOString().split('T')[0] : 'unknown';
+      const dateStr = (order.deliveryDate || order.updatedAt).toISOString().split('T')[0];
       if (!dailyProfitability[dateStr]) {
         dailyProfitability[dateStr] = {
           date: dateStr,
@@ -1662,7 +1662,7 @@ export class FinancialService {
     const aggregations = await prisma.accountTransaction.groupBy({
       by: ['accountId'],
       where: {
-        createdAt: { lte: asOfDate }
+        journalEntry: { isVoided: false, entryDate: { lte: asOfDate } }
       },
       _sum: {
         debitAmount: true,

--- a/backend/src/services/orderService.ts
+++ b/backend/src/services/orderService.ts
@@ -1138,6 +1138,7 @@ export class OrderService {
         where: { id: orderId },
         data: {
           status: data.status,
+          deliveryDate: data.status === 'delivered' ? new Date() : undefined,
           paymentStatus: data.status === 'delivered' ? 'collected' : order.paymentStatus,
           ...(isReturnStatus && order.revenueRecognized ? { revenueRecognized: false } : {}),
           orderHistory: {


### PR DESCRIPTION
## Summary

- **Set `deliveryDate` on delivery completion** — both `completeDelivery()` and manual `updateOrderStatus()` now set `deliveryDate: new Date()` when orders are delivered, fixing the empty Profitability Analysis
- **Fix Balance Sheet date filter** — changed from `AccountTransaction.createdAt` to `journalEntry.entryDate` with `isVoided: false` filter, matching the P&L pattern for proper accrual accounting
- **Fix profitability daily grouping** — fallback from `deliveryDate` to `updatedAt` instead of `'unknown'` bucket
- **Add `POST /api/financial/backfill-delivery-dates`** — admin endpoint to set `deliveryDate` on existing delivered orders using orderHistory timestamps

## Root Causes

1. `deliveryDate` was never set by the two main delivery flows, only by bulk import — profitability query filters on this field
2. Balance Sheet used `AccountTransaction.createdAt` instead of `JournalEntry.entryDate` for date filtering
3. Commission issues (P&L showing GHS 0.00) likely caused by agent `commissionAmount = 0` — needs production investigation after deploy

## Post-Deploy Steps

1. Call `POST /api/financial/backfill-delivery-dates` on production
2. Verify agent/rep `commissionAmount` values in DB
3. Check financial module tabs for correct data

## Test plan

- [x] TypeScript builds clean
- [x] 315 backend unit tests pass
- [x] 66 frontend tests pass
- [x] ESLint passes
- [x] GitHub workflow validation passes
- [x] Backfill endpoint returns correct response locally
- [x] Balance Sheet and Profitability APIs respond without errors
- [x] All financial UI tabs render without errors
- [ ] Deploy to staging and verify with production-like data
- [ ] Run backfill on production after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)