### PR TITLE
fix: use GL revenue as single source of truth for Profitability Analysis

### DIFF
--- a/backend/src/services/financialService.ts
+++ b/backend/src/services/financialService.ts
@@ -1136,15 +1136,24 @@ export class FinancialService {
       }
     }
 
-    // Query ALL expense accounts from GL using entryDate (same filter as P&L / Overview)
-    // This ensures COGS, commissions, and operating expenses all come from GL,
-    // matching the Overview's single-source-of-truth approach.
+    // Query GL using entryDate (same filter as P&L / Overview) — single source of truth
     const glEntryDateFilter: any = {};
     if (startDate || endDate) {
       glEntryDateFilter.entryDate = {};
       if (startDate) glEntryDateFilter.entryDate.gte = startDate;
       if (endDate) glEntryDateFilter.entryDate.lte = endDate;
     }
+
+    // GL Revenue — use account 4010 (same as Overview) so numbers always match
+    const revenueAgg = await prisma.accountTransaction.aggregate({
+      where: {
+        account: { code: GL_ACCOUNTS.PRODUCT_REVENUE },
+        journalEntry: { isVoided: false, ...glEntryDateFilter }
+      },
+      _sum: { debitAmount: true, creditAmount: true }
+    });
+    // Revenue account has credit-normal balance
+    const glRevenue = this.toNumber(revenueAgg._sum.creditAmount) - this.toNumber(revenueAgg._sum.debitAmount);
 
     const commissionCodes = [GL_ACCOUNTS.DELIVERY_AGENT_COMMISSION, GL_ACCOUNTS.SALES_REP_COMMISSION];
 
@@ -1181,12 +1190,12 @@ export class FinancialService {
       .filter(r => !commissionIdSet.has(r.accountId) && !cogsIdSet.has(r.accountId))
       .reduce((sum, r) => sum + this.toNumber(r._sum.debitAmount) - this.toNumber(r._sum.creditAmount), 0);
 
-    // Use GL COGS for summary totals (matches Overview), keep per-product COGS for breakdown
-    const grossProfit = totalRevenue - glCOGS;
-    const grossMargin = totalRevenue > 0 ? (grossProfit / totalRevenue) * 100 : 0;
+    // Use GL revenue + GL COGS for summary totals (matches Overview exactly)
+    const grossProfit = glRevenue - glCOGS;
+    const grossMargin = glRevenue > 0 ? (grossProfit / glRevenue) * 100 : 0;
 
     const netProfit = grossProfit - totalCommissions - totalOperatingExpenses;
-    const netMargin = totalRevenue > 0 ? (netProfit / totalRevenue) * 100 : 0;
+    const netMargin = glRevenue > 0 ? (netProfit / glRevenue) * 100 : 0;
 
     // Format product profitability
     const products = Object.values(productProfitability).map(p => ({
@@ -1210,7 +1219,7 @@ export class FinancialService {
 
     return {
       summary: {
-        totalRevenue,
+        totalRevenue: glRevenue,
         totalCOGS: glCOGS,
         totalShippingCost,
         totalDiscount,
@@ -1222,7 +1231,7 @@ export class FinancialService {
         netMargin,
         orderCount: orders.length,
         dataSources: {
-          revenue: 'Order.totalAmount (matches GL 4010)',
+          revenue: 'GL account 4010 (matches Overview)',
           cogs: 'GL account 5010 (matches Overview)',
           commissions: 'GL accounts 5040/5050 (accrual)',
           operatingExpenses: 'GL non-COGS, non-commission expense accounts',


### PR DESCRIPTION
## Summary
- Profitability Analysis now queries GL account 4010 for revenue instead of summing `order.totalAmount` by `deliveryDate`
- This matches exactly how the Overview tab computes revenue, ensuring Net Profit is consistent across both views
- Root cause: backfilled orders have `deliveryDate` in January but GL `entryDate` in February, causing revenue mismatches when filtering by date range

## Test plan
- [x] TypeScript builds successfully
- [x] All 315 unit tests pass
- [ ] Deploy to staging and verify Feb filter shows same Net Profit on Overview and Profitability tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)