### PR TITLE
fix: align product breakdown table with GL date filter

### DIFF
--- a/backend/src/services/financialService.ts
+++ b/backend/src/services/financialService.ts
@@ -1024,7 +1024,9 @@ export class FinancialService {
       endDate.setHours(23, 59, 59, 999);
     }
 
-    // Filters for delivered orders with GL revenue recognition
+    // Filter orders by GL journal entry date (not deliveryDate) so breakdowns
+    // align with the GL-based summary KPIs. deliveryDate and GL entryDate can
+    // diverge for backfilled orders.
     const orderWhere: Prisma.OrderWhereInput = {
       status: 'delivered',
       revenueRecognized: true,
@@ -1032,9 +1034,15 @@ export class FinancialService {
     };
 
     if (startDate || endDate) {
-      orderWhere.deliveryDate = {};
-      if (startDate) orderWhere.deliveryDate.gte = startDate;
-      if (endDate) orderWhere.deliveryDate.lte = endDate;
+      orderWhere.glJournalEntry = {
+        isVoided: false,
+        ...(startDate || endDate ? {
+          entryDate: {
+            ...(startDate ? { gte: startDate } : {}),
+            ...(endDate ? { lte: endDate } : {}),
+          }
+        } : {}),
+      };
     }
 
     if (productId) {


### PR DESCRIPTION
## Summary
- Product Profitability table now filters orders by `glJournalEntry.entryDate` instead of `deliveryDate`
- This ensures the table breakdown matches the GL-based summary KPIs (revenue, COGS, net profit)
- Fixes the issue where the table showed 53 qty / GHS 12,150 while the KPIs showed GHS 117,225

## Test plan
- [x] TypeScript builds
- [x] All 315 unit tests pass
- [ ] Verify on staging: product table revenue should align with summary revenue

🤖 Generated with [Claude Code](https://claude.com/claude-code)