### PR TITLE
fix: allow iframe embedding for public checkout pages

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -187,6 +187,23 @@ http {
             add_header Cache-Control "public, immutable";
         }
 
+        # Public checkout pages - allow iframe embedding on external sites
+        location /order {
+            limit_req zone=general_limit burst=50 nodelay;
+
+            proxy_pass http://frontend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # No X-Frame-Options here - allow iframe embedding
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
+        }
+
         # Frontend application
         location / {
             limit_req zone=general_limit burst=50 nodelay;
@@ -263,6 +280,20 @@ http {
             proxy_connect_timeout 7d;
             proxy_send_timeout 7d;
             proxy_read_timeout 7d;
+        }
+
+        # Public checkout pages - allow iframe embedding on external sites
+        location /order {
+            proxy_pass http://172.17.0.1:5174;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # No X-Frame-Options here - allow iframe embedding
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
         }
 
         # Frontend → Staging frontend on localhost:5174

--- a/nginx/staging.codadminpro.com
+++ b/nginx/staging.codadminpro.com
@@ -19,6 +19,22 @@ add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header X-XSS-Protection "1; mode=block" always;
 
+# Public checkout pages - allow iframe embedding on external sites
+    location /order {
+         proxy_pass http://localhost:5174;
+         proxy_http_version 1.1;
+         proxy_set_header Upgrade $http_upgrade;
+         proxy_set_header Connection 'upgrade';
+         proxy_set_header Host $host;
+         proxy_set_header X-Real-IP $remote_addr;
+         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+         proxy_set_header X-Forwarded-Proto $scheme;
+         proxy_cache_bypass $http_upgrade;
+
+         # No X-Frame-Options here - allow iframe embedding
+         add_header X-Content-Type-Options "nosniff" always;
+    }
+
 # Frontend (React app)
     location / {
          proxy_pass http://localhost:5174;


### PR DESCRIPTION
## Summary
- Add dedicated `/order` nginx location blocks that omit `X-Frame-Options` header
- Allows checkout forms to be embedded via iframe on external sites (e.g., WordPress on goshop.com.ng)
- All other pages retain `X-Frame-Options "SAMEORIGIN"` protection

## Test plan
- [ ] Deploy to staging and verify `/order/*` pages load in an iframe from an external domain
- [ ] Verify admin pages still block iframe embedding (SAMEORIGIN)
- [ ] Test checkout form submission works through the iframe

🤖 Generated with [Claude Code](https://claude.com/claude-code)