### PR TITLE
fix: checkout thank you page alignment in iframe

### DIFF
--- a/frontend/src/components/public/OrderSuccess.tsx
+++ b/frontend/src/components/public/OrderSuccess.tsx
@@ -20,7 +20,7 @@ export const OrderSuccess: React.FC<OrderSuccessProps> = ({ orderId, orderTotal,
   }, []); // intentionally empty — fires once on mount
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center py-12 px-4">
+    <div className="bg-gray-50 flex items-center justify-center py-12 px-4">
       <div className="max-w-md w-full bg-white rounded-lg shadow-lg border border-gray-200 p-8 text-center">
         {/* Success Icon */}
         <div className="flex justify-center mb-6">


### PR DESCRIPTION
## Summary
- Remove `min-h-screen` from OrderSuccess component
- Fixes large empty space above the success card when embedded in an iframe on external sites (e.g., WordPress)

## Test plan
- [ ] Submit order through iframe-embedded checkout on WordPress
- [ ] Verify thank you page content appears at the top without empty space
- [ ] Verify standalone checkout page still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)