### PR TITLE
fix: Facebook pixel image beacon fallback

### DIFF
--- a/frontend/src/utils/pixelTracking.ts
+++ b/frontend/src/utils/pixelTracking.ts
@@ -14,6 +14,10 @@ declare global {
   }
 }
 
+function generateEventId(): string | undefined {
+  return typeof crypto?.randomUUID === 'function' ? crypto.randomUUID() : undefined;
+}
+
 function sendFbPixelBeacon(pixelId: string, event: string, params?: Record<string, string | number>, eventId?: string): void {
   const url = new URL('https://www.facebook.com/tr');
   url.searchParams.set('id', pixelId);
@@ -36,19 +40,23 @@ function sendFbPixelBeacon(pixelId: string, event: string, params?: Record<strin
 }
 
 function loadFacebookPixel(pixelId: string): void {
-  if (window.fbq) return;
+  const eventId = generateEventId();
 
-  // Inject Facebook's exact standard pixel snippet via inline script.
-  // This must run as a single inline script to ensure fbevents.js
-  // fully initializes its internal pipeline (plugins, beacon sender).
-  const eventId = crypto.randomUUID();
-  const script = document.createElement('script');
-  script.textContent = `!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,document,'script','https://connect.facebook.net/en_US/fbevents.js');fbq('init','${pixelId}');fbq('track','PageView',{},{eventID:'${eventId}'});`;
-  document.head.appendChild(script);
+  if (!window.fbq) {
+    // Inject Facebook's exact standard pixel snippet via inline script.
+    // This must run as a single inline script to ensure fbevents.js
+    // fully initializes its internal pipeline (plugins, beacon sender).
+    const script = document.createElement('script');
+    script.textContent = eventId
+      ? `!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,document,'script','https://connect.facebook.net/en_US/fbevents.js');fbq('init','${pixelId}');fbq('track','PageView',{},{eventID:'${eventId}'});`
+      : `!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,document,'script','https://connect.facebook.net/en_US/fbevents.js');fbq('init','${pixelId}');fbq('track','PageView');`;
+    document.head.appendChild(script);
+  }
 
-  // Direct image beacon fallback — guarantees PageView reaches Facebook
-  // even if fbevents.js fails to send network beacons.
-  // Shared eventID allows Facebook to deduplicate if both paths fire.
+  // NOTE: Both fbq and the image beacon always fire together.
+  // Facebook deduplicates via the shared eventID.
+  // Intentional: fbevents.js can silently drop beacons even when fbq exists,
+  // and fbq may have been pre-loaded by a parent page (e.g. GTM on WordPress).
   sendFbPixelBeacon(pixelId, 'PageView', undefined, eventId);
 }
 
@@ -128,11 +136,13 @@ export function initPixels(config: PixelConfig): void {
 
 export function trackPurchase(config: PixelConfig, value: number, currency: string, orderId?: number | string): void {
   if (config.facebookPixelId) {
-    const eventId = crypto.randomUUID();
+    const eventId = generateEventId();
     if (window.fbq) {
-      window.fbq('track', 'Purchase', { value, currency }, { eventID: eventId });
+      window.fbq('track', 'Purchase', { value, currency }, eventId ? { eventID: eventId } : {});
     }
-    // Image beacon fallback with shared eventID for deduplication
+    // NOTE: Both fbq and the image beacon always fire together.
+    // Facebook deduplicates via the shared eventID.
+    // Intentional: fbevents.js can silently drop beacons even when fbq exists.
     sendFbPixelBeacon(config.facebookPixelId, 'Purchase', { value, currency }, eventId);
   }
 


### PR DESCRIPTION
## Summary
- Add direct image beacon fallback for Facebook pixel PageView and Purchase events
- fbevents.js loads but silently drops network beacons; image pixel fallback (same mechanism as Facebook's `<noscript>` tag) guarantees events reach Facebook
- Verified locally: both PageView and Purchase beacons fire correctly

## Test plan
- [ ] Open checkout page, verify `facebook.com/tr` image request in Network tab
- [ ] Submit order, verify Purchase beacon fires on thank you page
- [ ] Check Meta Events Manager for received events

🤖 Generated with [Claude Code](https://claude.com/claude-code)