### PR TITLE
fix: Facebook pixel image beacon fallback

### DIFF
--- a/frontend/src/utils/pixelTracking.ts
+++ b/frontend/src/utils/pixelTracking.ts
@@ -63,6 +63,11 @@ function loadFacebookPixel(pixelId: string): void {
       ? `!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,document,'script','https://connect.facebook.net/en_US/fbevents.js');fbq('init','${pixelId}');fbq('track','PageView',{},{eventID:'${eventId}'});`
       : `!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,document,'script','https://connect.facebook.net/en_US/fbevents.js');fbq('init','${pixelId}');fbq('track','PageView');`;
     document.head.appendChild(script);
+  } else {
+    // fbq already exists (e.g. GTM on WordPress parent page) —
+    // still need to register our pixel ID so trackPurchase events route correctly
+    window.fbq('init', pixelId);
+    window.fbq('track', 'PageView', {}, eventId ? { eventID: eventId } : {});
   }
 
   // NOTE: Both fbq and the image beacon always fire together.


### PR DESCRIPTION
## Summary
- Add direct image beacon fallback for Facebook pixel PageView and Purchase events
- fbevents.js loads but silently drops network beacons; image pixel fallback guarantees events reach Facebook
- Event deduplication via shared eventID prevents double-counting
- Handles non-secure contexts (HTTP iframes) and pre-loaded fbq (GTM on parent pages)

## Test plan
- [ ] Verify PageView and Purchase events appear in Meta Events Manager
- [ ] Test checkout flow on codadminpro.com and via WordPress iframe embed
- [ ] Confirm no duplicate events in Events Manager (eventID dedup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)