### PR TITLE
feat: complete agent inventory Phase 2 (MAN-23)

### DIFF
--- a/backend/src/controllers/agentInventoryController.ts
+++ b/backend/src/controllers/agentInventoryController.ts
@@ -113,7 +113,14 @@ class AgentInventoryController {
 
   async getTransferHistory(req: AuthRequest, res: Response) {
     try {
-      const { productId, agentId, type, startDate, endDate, page, limit } = req.query;
+      const { productId, type, startDate, endDate, page, limit } = req.query;
+      let { agentId } = req.query;
+
+      // Self-ownership check: delivery_agents may only view their own transfers.
+      if (req.user!.role === 'delivery_agent') {
+        agentId = String(req.user!.id);
+      }
+
       const result = await agentInventoryService.getTransferHistory({
         productId: productId ? parseInt(productId as string) : undefined,
         agentId: agentId ? parseInt(agentId as string) : undefined,

--- a/backend/src/routes/agentInventoryRoutes.ts
+++ b/backend/src/routes/agentInventoryRoutes.ts
@@ -82,7 +82,7 @@ router.get(
 
 router.get(
   '/transfers',
-  requireRole('super_admin', 'admin', 'manager', 'inventory_manager', 'accountant'),
+  requireRole('super_admin', 'admin', 'manager', 'inventory_manager', 'accountant', 'delivery_agent'),
   [
     query('productId').optional().isInt().toInt(),
     query('agentId').optional().isInt().toInt(),


### PR DESCRIPTION
## Summary
- Added `delivery_agent` role to the `/transfers` GET route so agents can view transfer history
- Added self-ownership enforcement in `getTransferHistory` — delivery agents are forced to query only their own transfers, while admins/managers retain full access
- Follows the same pattern already used in `getAgentInventory` for consistency

Closes MAN-23 (3/5 tasks were already complete; this finishes the remaining 2 backend security tasks)

## Test plan
- [ ] Verify delivery agent can access `/api/agent-inventory/transfers` (previously returned 403)
- [ ] Verify delivery agent only sees their own transfers (cannot pass another agent's ID)
- [ ] Verify admin/manager can still filter transfers by any agent ID
- [ ] Backend build, lint, and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)