### PR TITLE
fix: webhook controller error handling and staging DB fix

### DIFF
--- a/backend/src/__tests__/unit/webhook.test.ts
+++ b/backend/src/__tests__/unit/webhook.test.ts
@@ -29,6 +29,7 @@ import { importOrdersViaWebhook } from '../../controllers/webhookController';
 describe('Webhook Controller', () => {
   let mockReq: any;
   let mockRes: any;
+  let mockNext: any;
 
   beforeEach(() => {
     mockReq = {
@@ -41,6 +42,7 @@ describe('Webhook Controller', () => {
       status: jest.fn().mockReturnThis(),
       json: jest.fn().mockReturnThis(),
     };
+    mockNext = jest.fn();
   });
 
   describe('importOrdersViaWebhook', () => {
@@ -87,7 +89,7 @@ describe('Webhook Controller', () => {
       prismaMock.order.count.mockResolvedValue(0);
       prismaMock.order.create.mockResolvedValue({} as any);
 
-      await importOrdersViaWebhook(mockReq, mockRes);
+      await importOrdersViaWebhook(mockReq, mockRes, mockNext);
 
       expect(mockRes.json).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -115,9 +117,10 @@ describe('Webhook Controller', () => {
       } as any);
       prismaMock.webhookLog.update.mockResolvedValue({} as any);
 
-      await expect(importOrdersViaWebhook(mockReq, mockRes)).rejects.toThrow(
-        'Invalid webhook signature'
-      );
+      await importOrdersViaWebhook(mockReq, mockRes, mockNext);
+      expect(mockNext).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'Invalid webhook signature'
+      }));
     });
 
     it('should reject invalid API key', async () => {
@@ -128,7 +131,10 @@ describe('Webhook Controller', () => {
       prismaMock.webhookConfig.findFirst.mockResolvedValue(null);
       prismaMock.webhookLog.update.mockResolvedValue({} as any);
 
-      await expect(importOrdersViaWebhook(mockReq, mockRes)).rejects.toThrow('Invalid API key');
+      await importOrdersViaWebhook(mockReq, mockRes, mockNext);
+      expect(mockNext).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'Invalid API key'
+      }));
     });
 
     it('should handle multiple orders in batch', async () => {
@@ -169,7 +175,7 @@ describe('Webhook Controller', () => {
       prismaMock.order.count.mockResolvedValue(0);
       prismaMock.order.create.mockResolvedValue({} as any);
 
-      await importOrdersViaWebhook(mockReq, mockRes);
+      await importOrdersViaWebhook(mockReq, mockRes, mockNext);
 
       expect(mockRes.json).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -201,7 +207,7 @@ describe('Webhook Controller', () => {
       prismaMock.order.findMany.mockResolvedValue([{ externalOrderId: 'dup-ext-1' }] as any);
       prismaMock.order.findFirst.mockResolvedValue(null);
 
-      await importOrdersViaWebhook(mockReq, mockRes);
+      await importOrdersViaWebhook(mockReq, mockRes, mockNext);
 
       expect(prismaMock.order.create).not.toHaveBeenCalled();
       expect(mockRes.json).toHaveBeenCalledWith(
@@ -223,7 +229,7 @@ describe('Webhook Controller', () => {
       prismaError.meta = { target: ['webhook_fingerprint'] };
       prismaMock.order.create.mockRejectedValue(prismaError);
 
-      await importOrdersViaWebhook(mockReq, mockRes);
+      await importOrdersViaWebhook(mockReq, mockRes, mockNext);
 
       expect(mockRes.json).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -240,7 +246,7 @@ describe('Webhook Controller', () => {
       prismaMock.order.findFirst.mockResolvedValue(null); // outside window
       prismaMock.order.create.mockResolvedValue({ id: 1000 } as any);
 
-      await importOrdersViaWebhook(mockReq, mockRes);
+      await importOrdersViaWebhook(mockReq, mockRes, mockNext);
 
       expect(prismaMock.order.create).toHaveBeenCalledTimes(1);
       expect(mockRes.json).toHaveBeenCalledWith(

--- a/backend/src/controllers/webhookController.ts
+++ b/backend/src/controllers/webhookController.ts
@@ -1,17 +1,17 @@
-import { Response, Request } from 'express';
+import { Response, Request, NextFunction } from 'express';
 import { AuthRequest } from '../types';
 import webhookService from '../services/webhookService';
 
-export const getAllWebhooks = async (_req: AuthRequest, res: Response): Promise<void> => {
+export const getAllWebhooks = async (_req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
   try {
     const webhooks = await webhookService.getAllWebhooks();
     res.json({ webhooks });
   } catch (error) {
-    throw error;
+    next(error);
   }
 };
 
-export const createWebhook = async (req: AuthRequest, res: Response): Promise<void> => {
+export const createWebhook = async (req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
   try {
     const { name, url, secret, productId, apiKey, fieldMapping, headers } = req.body;
 
@@ -27,42 +27,42 @@ export const createWebhook = async (req: AuthRequest, res: Response): Promise<vo
 
     res.status(201).json({ webhook });
   } catch (error) {
-    throw error;
+    next(error);
   }
 };
 
-export const getWebhook = async (req: AuthRequest, res: Response): Promise<void> => {
+export const getWebhook = async (req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
   try {
     const { id } = req.params;
     const webhook = await webhookService.getWebhookById(Number(id));
     res.json({ webhook });
   } catch (error) {
-    throw error;
+    next(error);
   }
 };
 
-export const updateWebhook = async (req: AuthRequest, res: Response): Promise<void> => {
+export const updateWebhook = async (req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
   try {
     const { id } = req.params;
     const updateData = req.body;
     const webhook = await webhookService.updateWebhook(Number(id), updateData);
     res.json({ webhook });
   } catch (error) {
-    throw error;
+    next(error);
   }
 };
 
-export const deleteWebhook = async (req: AuthRequest, res: Response): Promise<void> => {
+export const deleteWebhook = async (req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
   try {
     const { id } = req.params;
     const result = await webhookService.deleteWebhook(Number(id));
     res.json(result);
   } catch (error) {
-    throw error;
+    next(error);
   }
 };
 
-export const importOrdersViaWebhook = async (req: Request, res: Response): Promise<void> => {
+export const importOrdersViaWebhook = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const signature = req.headers['x-webhook-signature'] as string;
     const apiKey = req.headers['x-api-key'] as string;
@@ -78,7 +78,7 @@ export const importOrdersViaWebhook = async (req: Request, res: Response): Promi
 
     res.json(result);
   } catch (error) {
-    throw error;
+    next(error);
   }
 };
 
@@ -86,7 +86,7 @@ export const importOrdersViaWebhook = async (req: Request, res: Response): Promi
  * Import orders via unique webhook URL
  * Simpler endpoint that doesn't require API keys in headers
  */
-export const importOrdersViaUniqueUrl = async (req: Request, res: Response): Promise<void> => {
+export const importOrdersViaUniqueUrl = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const { uniqueUrl } = req.params;
     const signature = req.headers['x-webhook-signature'] as string;
@@ -102,11 +102,11 @@ export const importOrdersViaUniqueUrl = async (req: Request, res: Response): Pro
 
     res.json(result);
   } catch (error) {
-    throw error;
+    next(error);
   }
 };
 
-export const getWebhookLogs = async (req: AuthRequest, res: Response): Promise<void> => {
+export const getWebhookLogs = async (req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
   try {
     const { id } = req.params;
     const { page = 1, limit = 20 } = req.query;
@@ -118,11 +118,11 @@ export const getWebhookLogs = async (req: AuthRequest, res: Response): Promise<v
 
     res.json(result);
   } catch (error) {
-    throw error;
+    next(error);
   }
 };
 
-export const testWebhook = async (req: AuthRequest, res: Response): Promise<void> => {
+export const testWebhook = async (req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
   try {
     const { id } = req.params;
     const { sampleData } = req.body;
@@ -130,6 +130,6 @@ export const testWebhook = async (req: AuthRequest, res: Response): Promise<void
     const result = await webhookService.testWebhook(Number(id), sampleData);
     res.json(result);
   } catch (error) {
-    throw error;
+    next(error);
   }
 };

--- a/backend/src/routes/webhookRoutes.ts
+++ b/backend/src/routes/webhookRoutes.ts
@@ -4,7 +4,7 @@ import { authenticate, requirePermission } from '../middleware/auth';
 import { tenantRateLimiter } from '../middleware/tenantRateLimiter';
 import { validate } from '../middleware/validation';
 import { paginationValidation } from '../utils/validators';
-import { webhookLimiter, apiLimiter } from '../middleware/rateLimiter';
+import { webhookLimiter } from '../middleware/rateLimiter';
 
 const router = Router();
 
@@ -12,8 +12,7 @@ const router = Router();
 router.post('/import/:uniqueUrl', webhookLimiter, webhookController.importOrdersViaUniqueUrl); // Unique URL-based import
 router.post('/import', webhookLimiter, webhookController.importOrdersViaWebhook); // Legacy API key-based import
 
-// Protected routes
-router.use(apiLimiter); // Rate limiting for authenticated webhook management
+// Protected routes (apiLimiter already applied at server level in server.ts)
 router.use(authenticate);
 router.use(tenantRateLimiter);
 


### PR DESCRIPTION
## Summary
- Webhook controller uses `next(error)` instead of `throw error` to prevent 30s timeouts
- Removed duplicate `apiLimiter` from webhook routes
- Fixed missing `tenant_id` column on `webhook_configs` table (staging + production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)