### PR TITLE
fix: webhook URL display, copy-to-clipboard, and missing stats route

### DIFF
--- a/backend/src/controllers/webhookController.ts
+++ b/backend/src/controllers/webhookController.ts
@@ -122,6 +122,21 @@ export const getWebhookLogs = async (req: AuthRequest, res: Response, next: Next
   }
 };
 
+export const getWebhookStats = async (req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const { days } = req.query;
+
+    const stats = await webhookService.getWebhookStats(Number(id), {
+      days: days ? Number(days) : undefined
+    });
+
+    res.json(stats);
+  } catch (error) {
+    next(error);
+  }
+};
+
 export const testWebhook = async (req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
   try {
     const { id } = req.params;

--- a/backend/src/routes/webhookRoutes.ts
+++ b/backend/src/routes/webhookRoutes.ts
@@ -21,6 +21,7 @@ router.post('/', requirePermission(['super_admin', 'admin']), webhookController.
 router.get('/:id', requirePermission(['super_admin', 'admin']), webhookController.getWebhook);
 router.put('/:id', requirePermission(['super_admin', 'admin']), webhookController.updateWebhook);
 router.delete('/:id', requirePermission(['super_admin', 'admin']), webhookController.deleteWebhook);
+router.get('/:id/stats', requirePermission(['super_admin', 'admin']), webhookController.getWebhookStats);
 router.get('/:id/logs', requirePermission(['super_admin', 'admin']), paginationValidation, validate, webhookController.getWebhookLogs);
 router.post('/:id/test', requirePermission(['super_admin', 'admin']), webhookController.testWebhook);
 

--- a/frontend/src/components/webhook/WebhookIntegrationDetails.tsx
+++ b/frontend/src/components/webhook/WebhookIntegrationDetails.tsx
@@ -26,7 +26,7 @@ export const WebhookIntegrationDetails: React.FC<WebhookIntegrationDetailsProps>
   const [copiedUrl, setCopiedUrl] = useState(false);
   const [copiedApiKey, setCopiedApiKey] = useState(false);
 
-  const webhookUrl = `${getApiBaseUrl()}/api/webhooks/import`;
+  const webhookUrl = `${getApiBaseUrl()}/api/webhooks/import/${webhook.uniqueUrl}`;
 
   const handleCopyUrl = async () => {
     try {

--- a/frontend/src/pages/Webhooks.tsx
+++ b/frontend/src/pages/Webhooks.tsx
@@ -28,6 +28,7 @@ export const Webhooks: React.FC = () => {
   const [isLogsOpen, setIsLogsOpen] = useState(false);
   const [deletingId, setDeletingId] = useState<number | null>(null);
   const [copiedApiKeyId, setCopiedApiKeyId] = useState<number | null>(null);
+  const [copiedUrlId, setCopiedUrlId] = useState<number | null>(null);
 
   useEffect(() => {
     fetchWebhooks();
@@ -64,6 +65,19 @@ export const Webhooks: React.FC = () => {
   const handleViewLogs = (webhook: Webhook) => {
     setSelectedWebhook(webhook);
     setIsLogsOpen(true);
+  };
+
+  const handleCopyUrl = async (webhook: Webhook) => {
+    const url = `${getApiBaseUrl()}/api/webhooks/import/${webhook.uniqueUrl}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedUrlId(webhook.id);
+      setTimeout(() => setCopiedUrlId(null), 2000);
+      toast.success('Webhook URL copied to clipboard');
+    } catch (error) {
+      console.error('Failed to copy URL:', error);
+      toast.error('Failed to copy URL');
+    }
   };
 
   const handleCopyApiKey = async (webhook: Webhook) => {
@@ -238,11 +252,26 @@ export const Webhooks: React.FC = () => {
                       </div>
                     </td>
                     <td className="px-6 py-4">
-                      <div className="text-sm text-gray-900">
+                      <div className="flex items-center gap-1.5">
                         <Tooltip content={`${getApiBaseUrl()}/api/webhooks/import/${webhook.uniqueUrl}`} position="top">
-                          <span className="truncate max-w-xs inline-block">
+                          <button
+                            onClick={() => handleCopyUrl(webhook)}
+                            className="text-sm text-gray-900 hover:text-blue-600 transition-colors truncate max-w-xs inline-block text-left cursor-pointer"
+                          >
                             {truncateUrl(`${getApiBaseUrl()}/api/webhooks/import/${webhook.uniqueUrl}`)}
-                          </span>
+                          </button>
+                        </Tooltip>
+                        <Tooltip content="Copy URL" position="top">
+                          <button
+                            onClick={() => handleCopyUrl(webhook)}
+                            className="text-gray-400 hover:text-gray-600 transition-colors flex-shrink-0"
+                          >
+                            {copiedUrlId === webhook.id ? (
+                              <CheckCircle className="w-3.5 h-3.5 text-green-600" />
+                            ) : (
+                              <Copy className="w-3.5 h-3.5" />
+                            )}
+                          </button>
                         </Tooltip>
                       </div>
                     </td>


### PR DESCRIPTION
## Summary
- Show actual unique webhook URL (with `uniqueUrl`) in integration details dialog and curl example instead of generic `/api/webhooks/import`
- Add click-to-copy functionality on webhook URLs in the webhooks table
- Add missing `GET /:id/stats` route and controller handler for webhook log statistics (fixes "Route not found" error on logs view)
- Use `next(error)` pattern in webhook controller for proper Express error handling (from previous commit)
- Remove duplicate API rate limiter from webhook routes (from previous commit)

## Test plan
- [ ] Create a new webhook and verify the success dialog shows the full unique URL
- [ ] Verify the curl example uses the correct unique URL
- [ ] Click the webhook URL in the table to copy it
- [ ] Open webhook logs and verify statistics load without error
- [ ] Verify webhook import still works via the unique URL endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)