### PR TITLE
Platform admin: layout, bootstrap script, CORS auto-derive

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "prisma:studio": "prisma studio",
     "prisma:migrate": "prisma migrate dev",
     "bootstrap": "ts-node scripts/bootstrap-admin.ts",
+    "create-platform-admin": "ts-node scripts/create-platform-admin.ts",
     "seed": "ts-node scripts/seed-comprehensive-data.ts",
     "seed:gl": "ts-node scripts/seed-gl-accounts.ts",
     "sync-financial": "ts-node scripts/sync-financial-data-simple.ts",

--- a/backend/scripts/bootstrap-admin.ts
+++ b/backend/scripts/bootstrap-admin.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import bcrypt from 'bcrypt';
-import * as readline from 'readline';
+import { promptInput, promptPassword } from './lib/prompts';
 
 const prisma = new PrismaClient();
 
@@ -23,72 +23,6 @@ interface AdminInput {
  * 2. Environment variables: Set BOOTSTRAP_ADMIN_EMAIL, BOOTSTRAP_ADMIN_PASSWORD, etc.
  */
 
-async function promptForInput(question: string): Promise<string> {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-
-  return new Promise((resolve) => {
-    rl.question(question, (answer) => {
-      rl.close();
-      resolve(answer.trim());
-    });
-  });
-}
-
-/**
- * Prompt for password with masked input (shows * for each character)
- * Uses Node.js readline in raw mode for secure input
- */
-async function promptForPassword(question: string): Promise<string> {
-  return new Promise((resolve) => {
-    const rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    });
-
-    let password = '';
-    process.stdout.write(question);
-
-    // Enable raw mode to capture individual keystrokes
-    if (process.stdin.isTTY) {
-      process.stdin.setRawMode(true);
-    }
-
-    process.stdin.on('data', (char) => {
-      const str = char.toString('utf-8');
-
-      // Handle different key inputs
-      if (str === '\n' || str === '\r' || str === '\u0004') {
-        // Enter or Ctrl+D - finish input
-        if (process.stdin.isTTY) {
-          process.stdin.setRawMode(false);
-        }
-        rl.close();
-        process.stdout.write('\n');
-        resolve(password);
-      } else if (str === '\u0003') {
-        // Ctrl+C - cancel
-        if (process.stdin.isTTY) {
-          process.stdin.setRawMode(false);
-        }
-        process.stdout.write('\n');
-        process.exit(0);
-      } else if (str === '\u007f' || str === '\b') {
-        // Backspace - remove last character
-        if (password.length > 0) {
-          password = password.slice(0, -1);
-          process.stdout.write('\b \b');
-        }
-      } else if (str >= ' ' && str <= '~') {
-        // Printable character - add to password
-        password += str;
-        process.stdout.write('*');
-      }
-    });
-  });
-}
 
 async function getAdminInputFromEnv(): Promise<AdminInput | null> {
   const email = process.env.BOOTSTRAP_ADMIN_EMAIL;
@@ -108,11 +42,11 @@ async function getAdminInputInteractive(): Promise<AdminInput> {
   console.log('\n📝 Please provide admin user details:');
   console.log('━'.repeat(50));
 
-  const email = await promptForInput('Email address: ');
-  const password = await promptForPassword('Password (min 8 characters): ');
-  const firstName = await promptForInput('First name (default: Admin): ') || 'Admin';
-  const lastName = await promptForInput('Last name (default: User): ') || 'User';
-  const phoneNumber = await promptForInput('Phone number (default: +1234567890): ') || '+1234567890';
+  const email = await promptInput('Email address: ');
+  const password = await promptPassword('Password (min 8 characters): ');
+  const firstName = await promptInput('First name (default: Admin): ') || 'Admin';
+  const lastName = await promptInput('Last name (default: User): ') || 'User';
+  const phoneNumber = await promptInput('Phone number (default: +1234567890): ') || '+1234567890';
 
   return { email, password, firstName, lastName, phoneNumber };
 }

--- a/backend/scripts/create-platform-admin.ts
+++ b/backend/scripts/create-platform-admin.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import bcrypt from 'bcrypt';
-import * as readline from 'readline';
+import { promptInput, promptPassword } from './lib/prompts';
 
 const prisma = new PrismaClient();
 
@@ -29,51 +29,6 @@ interface PlatformAdminInput {
  * if a new one is supplied.
  */
 
-const CTRL_C = String.fromCharCode(3);
-const CTRL_D = String.fromCharCode(4);
-const DEL = String.fromCharCode(127);
-
-async function promptInput(question: string): Promise<string> {
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  return new Promise((resolve) => {
-    rl.question(question, (answer) => {
-      rl.close();
-      resolve(answer.trim());
-    });
-  });
-}
-
-async function promptPassword(question: string): Promise<string> {
-  return new Promise((resolve) => {
-    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-    let password = '';
-    process.stdout.write(question);
-    if (process.stdin.isTTY) process.stdin.setRawMode(true);
-
-    process.stdin.on('data', (char) => {
-      const str = char.toString('utf-8');
-      if (str === '\n' || str === '\r' || str === CTRL_D) {
-        if (process.stdin.isTTY) process.stdin.setRawMode(false);
-        rl.close();
-        process.stdout.write('\n');
-        resolve(password);
-      } else if (str === CTRL_C) {
-        if (process.stdin.isTTY) process.stdin.setRawMode(false);
-        process.stdout.write('\n');
-        process.exit(0);
-      } else if (str === DEL || str === '\b') {
-        if (password.length > 0) {
-          password = password.slice(0, -1);
-          process.stdout.write('\b \b');
-        }
-      } else if (str >= ' ' && str <= '~') {
-        password += str;
-        process.stdout.write('*');
-      }
-    });
-  });
-}
-
 function getInputFromEnv(): PlatformAdminInput | null {
   const email = process.env.PLATFORM_ADMIN_EMAIL;
   const password = process.env.PLATFORM_ADMIN_PASSWORD;
@@ -83,10 +38,7 @@ function getInputFromEnv(): PlatformAdminInput | null {
   return null;
 }
 
-async function getInputInteractive(existingUser: boolean): Promise<PlatformAdminInput> {
-  console.log('\nPlatform admin details:');
-  console.log('-'.repeat(50));
-  const email = await promptInput('Email: ');
+async function getInputInteractive(email: string, existingUser: boolean): Promise<PlatformAdminInput> {
   const password = await promptPassword(
     existingUser
       ? 'New password (leave blank to keep existing): '
@@ -100,12 +52,15 @@ async function getInputInteractive(existingUser: boolean): Promise<PlatformAdmin
 function validateInput(input: PlatformAdminInput, existingUser: boolean): string[] {
   const errors: string[] = [];
   if (!input.email || !input.email.includes('@')) errors.push('Invalid email');
-  if (!existingUser && (!input.password || input.password.length < 8)) {
+
+  const passwordRequired = !existingUser;
+  const passwordProvided = !!input.password && input.password.length > 0;
+  if (passwordRequired && !passwordProvided) {
+    errors.push('Password must be at least 8 characters');
+  } else if (passwordProvided && input.password.length < 8) {
     errors.push('Password must be at least 8 characters');
   }
-  if (existingUser && input.password && input.password.length > 0 && input.password.length < 8) {
-    errors.push('Password must be at least 8 characters');
-  }
+
   if (!input.firstName || input.firstName.length < 2) errors.push('First name too short');
   if (!input.lastName || input.lastName.length < 2) errors.push('Last name too short');
   return errors;
@@ -128,13 +83,14 @@ async function run(): Promise<void> {
       console.error('Set PLATFORM_ADMIN_EMAIL and PLATFORM_ADMIN_PASSWORD, or run interactively.');
       process.exit(1);
     }
-    const tempEmail = await promptInput('Email: ');
+    console.log('\nPlatform admin details:');
+    console.log('-'.repeat(50));
+    const email = await promptInput('Email: ');
     existingUser = await prisma.user.findUnique({
-      where: { email: tempEmail },
+      where: { email },
       select: { id: true, email: true, isPlatformAdmin: true },
     });
-    const rest = await getInputInteractive(!!existingUser);
-    input = { ...rest, email: tempEmail };
+    input = await getInputInteractive(email, !!existingUser);
   }
 
   const errors = validateInput(input, !!existingUser);

--- a/backend/scripts/create-platform-admin.ts
+++ b/backend/scripts/create-platform-admin.ts
@@ -1,0 +1,201 @@
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcrypt';
+import * as readline from 'readline';
+
+const prisma = new PrismaClient();
+
+interface PlatformAdminInput {
+  email: string;
+  password: string;
+  firstName: string;
+  lastName: string;
+}
+
+/**
+ * Create or promote a platform admin user.
+ *
+ * Platform admins have isPlatformAdmin=true and tenantId=null — they bypass
+ * tenant scoping (via prismaExtensions.ts) and can manage all tenants via
+ * /api/platform/* endpoints.
+ *
+ * Modes:
+ *   Env-driven:  PLATFORM_ADMIN_EMAIL, PLATFORM_ADMIN_PASSWORD,
+ *                PLATFORM_ADMIN_FIRST_NAME (optional),
+ *                PLATFORM_ADMIN_LAST_NAME  (optional)
+ *   Interactive: npm run create-platform-admin and answer prompts
+ *
+ * Promote-or-create: if a user with that email exists, this script promotes
+ * them (sets isPlatformAdmin=true, tenantId=null). Password is updated only
+ * if a new one is supplied.
+ */
+
+const CTRL_C = String.fromCharCode(3);
+const CTRL_D = String.fromCharCode(4);
+const DEL = String.fromCharCode(127);
+
+async function promptInput(question: string): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+async function promptPassword(question: string): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    let password = '';
+    process.stdout.write(question);
+    if (process.stdin.isTTY) process.stdin.setRawMode(true);
+
+    process.stdin.on('data', (char) => {
+      const str = char.toString('utf-8');
+      if (str === '\n' || str === '\r' || str === CTRL_D) {
+        if (process.stdin.isTTY) process.stdin.setRawMode(false);
+        rl.close();
+        process.stdout.write('\n');
+        resolve(password);
+      } else if (str === CTRL_C) {
+        if (process.stdin.isTTY) process.stdin.setRawMode(false);
+        process.stdout.write('\n');
+        process.exit(0);
+      } else if (str === DEL || str === '\b') {
+        if (password.length > 0) {
+          password = password.slice(0, -1);
+          process.stdout.write('\b \b');
+        }
+      } else if (str >= ' ' && str <= '~') {
+        password += str;
+        process.stdout.write('*');
+      }
+    });
+  });
+}
+
+function getInputFromEnv(): PlatformAdminInput | null {
+  const email = process.env.PLATFORM_ADMIN_EMAIL;
+  const password = process.env.PLATFORM_ADMIN_PASSWORD;
+  const firstName = process.env.PLATFORM_ADMIN_FIRST_NAME || 'Platform';
+  const lastName = process.env.PLATFORM_ADMIN_LAST_NAME || 'Admin';
+  if (email && password) return { email, password, firstName, lastName };
+  return null;
+}
+
+async function getInputInteractive(existingUser: boolean): Promise<PlatformAdminInput> {
+  console.log('\nPlatform admin details:');
+  console.log('-'.repeat(50));
+  const email = await promptInput('Email: ');
+  const password = await promptPassword(
+    existingUser
+      ? 'New password (leave blank to keep existing): '
+      : 'Password (min 8 chars): '
+  );
+  const firstName = (await promptInput('First name (default: Platform): ')) || 'Platform';
+  const lastName = (await promptInput('Last name (default: Admin): ')) || 'Admin';
+  return { email, password, firstName, lastName };
+}
+
+function validateInput(input: PlatformAdminInput, existingUser: boolean): string[] {
+  const errors: string[] = [];
+  if (!input.email || !input.email.includes('@')) errors.push('Invalid email');
+  if (!existingUser && (!input.password || input.password.length < 8)) {
+    errors.push('Password must be at least 8 characters');
+  }
+  if (existingUser && input.password && input.password.length > 0 && input.password.length < 8) {
+    errors.push('Password must be at least 8 characters');
+  }
+  if (!input.firstName || input.firstName.length < 2) errors.push('First name too short');
+  if (!input.lastName || input.lastName.length < 2) errors.push('Last name too short');
+  return errors;
+}
+
+async function run(): Promise<void> {
+  console.log('Create or promote platform admin');
+
+  let input = getInputFromEnv();
+  let existingUser: { id: number; email: string; isPlatformAdmin: boolean } | null = null;
+
+  if (input) {
+    existingUser = await prisma.user.findUnique({
+      where: { email: input.email },
+      select: { id: true, email: true, isPlatformAdmin: true },
+    });
+  } else {
+    if (!process.stdin.isTTY) {
+      console.error('No credentials provided.');
+      console.error('Set PLATFORM_ADMIN_EMAIL and PLATFORM_ADMIN_PASSWORD, or run interactively.');
+      process.exit(1);
+    }
+    const tempEmail = await promptInput('Email: ');
+    existingUser = await prisma.user.findUnique({
+      where: { email: tempEmail },
+      select: { id: true, email: true, isPlatformAdmin: true },
+    });
+    const rest = await getInputInteractive(!!existingUser);
+    input = { ...rest, email: tempEmail };
+  }
+
+  const errors = validateInput(input, !!existingUser);
+  if (errors.length) {
+    console.error('Invalid input:');
+    errors.forEach((e) => console.error(`  - ${e}`));
+    process.exit(1);
+  }
+
+  const data: {
+    isPlatformAdmin: boolean;
+    isActive: boolean;
+    tenantId: null;
+    password?: string;
+  } = {
+    isPlatformAdmin: true,
+    isActive: true,
+    tenantId: null,
+  };
+  if (input.password && input.password.length >= 8) {
+    data.password = await bcrypt.hash(input.password, 10);
+  }
+
+  let user;
+  if (existingUser) {
+    user = await prisma.user.update({
+      where: { id: existingUser.id },
+      data,
+    });
+    console.log(`\nPromoted existing user to platform admin: ${user.email}`);
+  } else {
+    user = await prisma.user.create({
+      data: {
+        email: input.email,
+        password: data.password!,
+        firstName: input.firstName,
+        lastName: input.lastName,
+        role: 'super_admin',
+        isActive: true,
+        isPlatformAdmin: true,
+        tenantId: null,
+      },
+    });
+    console.log(`\nCreated new platform admin: ${user.email}`);
+  }
+
+  console.log('-'.repeat(50));
+  console.log(`User ID:         ${user.id}`);
+  console.log(`Email:           ${user.email}`);
+  console.log(`Name:            ${user.firstName} ${user.lastName}`);
+  console.log(`isPlatformAdmin: ${user.isPlatformAdmin}`);
+  console.log(`tenantId:        ${user.tenantId ?? 'null (cross-tenant)'}`);
+  console.log('-'.repeat(50));
+  console.log('\nSign in at https://platform.codadminpro.com/login');
+}
+
+run()
+  .catch((error) => {
+    console.error('Error:', error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/scripts/lib/prompts.ts
+++ b/backend/scripts/lib/prompts.ts
@@ -1,0 +1,46 @@
+import * as readline from 'readline';
+
+const CTRL_C = String.fromCharCode(3);
+const CTRL_D = String.fromCharCode(4);
+const DEL = String.fromCharCode(127);
+
+export async function promptInput(question: string): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+export async function promptPassword(question: string): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    let password = '';
+    process.stdout.write(question);
+    if (process.stdin.isTTY) process.stdin.setRawMode(true);
+
+    process.stdin.on('data', (char) => {
+      const str = char.toString('utf-8');
+      if (str === '\n' || str === '\r' || str === CTRL_D) {
+        if (process.stdin.isTTY) process.stdin.setRawMode(false);
+        rl.close();
+        process.stdout.write('\n');
+        resolve(password);
+      } else if (str === CTRL_C) {
+        if (process.stdin.isTTY) process.stdin.setRawMode(false);
+        process.stdout.write('\n');
+        process.exit(0);
+      } else if (str === DEL || str === '\b') {
+        if (password.length > 0) {
+          password = password.slice(0, -1);
+          process.stdout.write('\b \b');
+        }
+      } else if (str >= ' ' && str <= '~') {
+        password += str;
+        process.stdout.write('*');
+      }
+    });
+  });
+}

--- a/backend/src/__tests__/unit/cors.test.ts
+++ b/backend/src/__tests__/unit/cors.test.ts
@@ -2,19 +2,7 @@ import { describe, it, expect } from '@jest/globals';
 import request from 'supertest';
 import express from 'express';
 import cors from 'cors';
-
-// Replicate the CORS setup from server.ts to unit-test the origin logic.
-function derivePlatformOrigin(frontendUrl: string): string | null {
-  try {
-    const url = new URL(frontendUrl);
-    if (!url.hostname || url.hostname === 'localhost' || url.hostname.startsWith('platform.')) {
-      return null;
-    }
-    return `${url.protocol}//platform.${url.hostname}`;
-  } catch {
-    return null;
-  }
-}
+import { derivePlatformOrigin } from '../../utils/corsOrigins';
 
 function makeApp(frontendUrl: string, platformUrl?: string) {
   const app = express();

--- a/backend/src/__tests__/unit/cors.test.ts
+++ b/backend/src/__tests__/unit/cors.test.ts
@@ -3,13 +3,26 @@ import request from 'supertest';
 import express from 'express';
 import cors from 'cors';
 
-// Replicate the CORS setup from server.ts to unit-test the origin logic
+// Replicate the CORS setup from server.ts to unit-test the origin logic.
+function derivePlatformOrigin(frontendUrl: string): string | null {
+  try {
+    const url = new URL(frontendUrl);
+    if (!url.hostname || url.hostname === 'localhost' || url.hostname.startsWith('platform.')) {
+      return null;
+    }
+    return `${url.protocol}//platform.${url.hostname}`;
+  } catch {
+    return null;
+  }
+}
+
 function makeApp(frontendUrl: string, platformUrl?: string) {
   const app = express();
+  const resolvedPlatform = platformUrl || derivePlatformOrigin(frontendUrl);
   app.use(cors({
     origin: [
       frontendUrl,
-      ...(platformUrl ? [platformUrl] : []),
+      ...(resolvedPlatform ? [resolvedPlatform] : []),
     ],
     credentials: true,
   }));
@@ -41,11 +54,49 @@ describe('CORS origin configuration', () => {
     expect(res.headers['access-control-allow-origin']).toBeUndefined();
   });
 
-  it('does not include platform origin when PLATFORM_URL is not set', async () => {
-    const appNoPlatform = makeApp('https://codadminpro.com');
-    const res = await request(appNoPlatform)
+  it('auto-derives platform subdomain from FRONTEND_URL when PLATFORM_URL is unset', async () => {
+    const appAutoDerive = makeApp('https://codadminpro.com');
+    const res = await request(appAutoDerive)
       .get('/test')
       .set('Origin', 'https://platform.codadminpro.com');
+    expect(res.headers['access-control-allow-origin']).toBe('https://platform.codadminpro.com');
+  });
+
+  it('explicit PLATFORM_URL overrides auto-derive', async () => {
+    const appCustom = makeApp('https://codadminpro.com', 'https://admin.codadminpro.com');
+    const res = await request(appCustom)
+      .get('/test')
+      .set('Origin', 'https://admin.codadminpro.com');
+    expect(res.headers['access-control-allow-origin']).toBe('https://admin.codadminpro.com');
+  });
+
+  it('does not auto-derive a platform origin for localhost', async () => {
+    const appLocal = makeApp('http://localhost:5173');
+    const res = await request(appLocal)
+      .get('/test')
+      .set('Origin', 'https://platform.localhost:5173');
     expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+});
+
+describe('derivePlatformOrigin', () => {
+  it('derives platform.<host> from apex frontend URL', () => {
+    expect(derivePlatformOrigin('https://codadminpro.com')).toBe('https://platform.codadminpro.com');
+  });
+
+  it('preserves protocol', () => {
+    expect(derivePlatformOrigin('http://example.test')).toBe('http://platform.example.test');
+  });
+
+  it('returns null for localhost', () => {
+    expect(derivePlatformOrigin('http://localhost:5173')).toBeNull();
+  });
+
+  it('returns null when frontend is already a platform subdomain', () => {
+    expect(derivePlatformOrigin('https://platform.codadminpro.com')).toBeNull();
+  });
+
+  it('returns null for invalid URL', () => {
+    expect(derivePlatformOrigin('not a url')).toBeNull();
   });
 });

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -40,6 +40,7 @@ import logger from './utils/logger';
 import { validateEnvironment } from './config/validateEnv';
 import { setSocketInstance } from './utils/socketInstance';
 import { validateGLAccountCodes } from './config/glAccounts';
+import { derivePlatformOrigin } from './utils/corsOrigins';
 
 // Routes
 import authRoutes from './routes/authRoutes';
@@ -144,21 +145,6 @@ app.use('/api/public', (_req, res, next) => {
 // SECURITY: Trust only the first proxy (nginx). Using `true` trusts ALL proxies,
 // allowing attackers to spoof X-Forwarded-For and bypass rate limiting.
 app.set("trust proxy", 1);
-
-// Auto-derive platform subdomain from FRONTEND_URL so a missing PLATFORM_URL
-// env doesn't silently break platform.<apex> logins. Explicit PLATFORM_URL
-// still wins when set.
-function derivePlatformOrigin(frontendUrl: string): string | null {
-  try {
-    const url = new URL(frontendUrl);
-    if (!url.hostname || url.hostname === 'localhost' || url.hostname.startsWith('platform.')) {
-      return null;
-    }
-    return `${url.protocol}//platform.${url.hostname}`;
-  } catch {
-    return null;
-  }
-}
 
 const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5173';
 const platformUrl = process.env.PLATFORM_URL || derivePlatformOrigin(frontendUrl);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -145,10 +145,28 @@ app.use('/api/public', (_req, res, next) => {
 // allowing attackers to spoof X-Forwarded-For and bypass rate limiting.
 app.set("trust proxy", 1);
 
+// Auto-derive platform subdomain from FRONTEND_URL so a missing PLATFORM_URL
+// env doesn't silently break platform.<apex> logins. Explicit PLATFORM_URL
+// still wins when set.
+function derivePlatformOrigin(frontendUrl: string): string | null {
+  try {
+    const url = new URL(frontendUrl);
+    if (!url.hostname || url.hostname === 'localhost' || url.hostname.startsWith('platform.')) {
+      return null;
+    }
+    return `${url.protocol}//platform.${url.hostname}`;
+  } catch {
+    return null;
+  }
+}
+
+const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5173';
+const platformUrl = process.env.PLATFORM_URL || derivePlatformOrigin(frontendUrl);
+
 app.use(cors({
   origin: [
-    process.env.FRONTEND_URL || 'http://localhost:5173',
-    ...(process.env.PLATFORM_URL ? [process.env.PLATFORM_URL] : []),
+    frontendUrl,
+    ...(platformUrl ? [platformUrl] : []),
   ],
   credentials: true,
 }));

--- a/backend/src/utils/corsOrigins.ts
+++ b/backend/src/utils/corsOrigins.ts
@@ -1,0 +1,16 @@
+/**
+ * Auto-derive `https://platform.<host>` from FRONTEND_URL so a missing
+ * PLATFORM_URL env doesn't silently break platform.<apex> logins. Returns
+ * null for localhost or when the frontend is already on a platform.* host.
+ */
+export function derivePlatformOrigin(frontendUrl: string): string | null {
+  try {
+    const url = new URL(frontendUrl);
+    if (!url.hostname || url.hostname === 'localhost' || url.hostname.startsWith('platform.')) {
+      return null;
+    }
+    return `${url.protocol}//platform.${url.hostname}`;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,6 +49,9 @@ const PlatformTenants = lazy(() => import('./pages/PlatformTenants').then(m => (
 const PlatformTenantDetail = lazy(() => import('./pages/PlatformTenantDetail').then(m => ({ default: m.PlatformTenantDetail })));
 const PlatformAnnouncements = lazy(() => import('./pages/PlatformAnnouncements').then(m => ({ default: m.PlatformAnnouncements })));
 
+// Platform admin layout (sidebar + outlet for the platform subdomain tree)
+const PlatformLayout = lazy(() => import('./components/layout/PlatformLayout').then(m => ({ default: m.PlatformLayout })));
+
 // Mobile pages
 const MobileLayout = lazy(() => import('./components/layout/MobileLayout').then(m => ({ default: m.MobileLayout })));
 const MobileDeliveries = lazy(() => import('./pages/mobile/MobileDeliveries'));
@@ -140,7 +143,7 @@ function App() {
     }
   }, [isAuthenticated, refreshPermissions, fetchConfig]);
 
-  // Platform subdomain — show only platform admin routes
+  // Platform subdomain — show only platform admin routes, wrapped in PlatformLayout
   if (isPlatformDomain()) {
     return (
       <ErrorBoundary>
@@ -149,10 +152,19 @@ function App() {
             <Route path="/login" element={
               <Suspense fallback={<Loading />}><PlatformLogin /></Suspense>
             } />
-            <Route path="/" element={platformRoute(PlatformDashboard)} />
-            <Route path="/tenants" element={platformRoute(PlatformTenants)} />
-            <Route path="/tenants/:id" element={platformRoute(PlatformTenantDetail)} />
-            <Route path="/announcements" element={platformRoute(PlatformAnnouncements)} />
+            <Route
+              path="/"
+              element={
+                <PlatformGuard>
+                  <Suspense fallback={<Loading />}><PlatformLayout /></Suspense>
+                </PlatformGuard>
+              }
+            >
+              <Route index element={<Suspense fallback={<Loading />}><PlatformDashboard /></Suspense>} />
+              <Route path="tenants" element={<Suspense fallback={<Loading />}><PlatformTenants /></Suspense>} />
+              <Route path="tenants/:id" element={<Suspense fallback={<Loading />}><PlatformTenantDetail /></Suspense>} />
+              <Route path="announcements" element={<Suspense fallback={<Loading />}><PlatformAnnouncements /></Suspense>} />
+            </Route>
             <Route path="*" element={<Navigate to="/login" replace />} />
           </Routes>
           <Toast />

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,19 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Outlet } from 'react-router-dom';
 import { Sidebar } from './Sidebar';
 import { Header } from './Header';
 import { cn } from '../../utils/cn';
 import { AnnouncementBanner } from '../announcements/AnnouncementBanner';
+import { useSidebarCollapse } from '../../hooks/useSidebarCollapse';
 
 export const Layout: React.FC = () => {
-  const [isCollapsed, setIsCollapsed] = useState(() => {
-    const saved = localStorage.getItem('sidebarCollapsed');
-    return saved ? JSON.parse(saved) : false;
-  });
-
-  useEffect(() => {
-    localStorage.setItem('sidebarCollapsed', JSON.stringify(isCollapsed));
-  }, [isCollapsed]);
+  const [isCollapsed, setIsCollapsed] = useSidebarCollapse('sidebarCollapsed');
 
   const toggleSidebar = () => setIsCollapsed(!isCollapsed);
 

--- a/frontend/src/components/layout/PlatformLayout.tsx
+++ b/frontend/src/components/layout/PlatformLayout.tsx
@@ -1,0 +1,99 @@
+import React, { useState, useEffect } from 'react';
+import { NavLink, Outlet } from 'react-router-dom';
+import {
+  LayoutDashboard,
+  Building2,
+  Megaphone,
+  ChevronLeft,
+  ChevronRight,
+} from 'lucide-react';
+import { cn } from '../../utils/cn';
+import { UserMenu } from '../common/UserMenu';
+
+const navItems = [
+  { path: '/', icon: LayoutDashboard, label: 'Dashboard', end: true },
+  { path: '/tenants', icon: Building2, label: 'Tenants', end: false },
+  { path: '/announcements', icon: Megaphone, label: 'Announcements', end: false },
+];
+
+export const PlatformLayout: React.FC = () => {
+  const [isCollapsed, setIsCollapsed] = useState(() => {
+    const saved = localStorage.getItem('platformSidebarCollapsed');
+    return saved ? JSON.parse(saved) : false;
+  });
+
+  useEffect(() => {
+    localStorage.setItem('platformSidebarCollapsed', JSON.stringify(isCollapsed));
+  }, [isCollapsed]);
+
+  return (
+    <div className="flex h-screen bg-gray-50">
+      <aside
+        className={cn(
+          'fixed left-0 top-0 h-full bg-gray-900 text-white p-4 transition-all duration-300 ease-in-out',
+          isCollapsed ? 'w-20' : 'w-64'
+        )}
+      >
+        <div className="mb-8 relative">
+          <div className={cn('flex items-center', isCollapsed ? 'flex-col gap-4' : 'justify-between')}>
+            <div className={cn('overflow-hidden', isCollapsed ? 'text-center' : '')}>
+              <h1 className={cn('font-bold transition-all', isCollapsed ? 'text-lg' : 'text-2xl')}>
+                {isCollapsed ? 'PA' : 'Platform Admin'}
+              </h1>
+              {!isCollapsed && <p className="text-gray-400 text-sm">Manage all tenants</p>}
+            </div>
+
+            <button
+              onClick={() => setIsCollapsed(!isCollapsed)}
+              className={cn(
+                'p-1 rounded-md hover:bg-gray-800 transition-colors',
+                isCollapsed ? '' : 'absolute top-0 right-0'
+              )}
+              aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            >
+              {isCollapsed ? <ChevronRight className="w-5 h-5" /> : <ChevronLeft className="w-5 h-5" />}
+            </button>
+          </div>
+        </div>
+
+        <nav className="space-y-1">
+          {navItems.map((item) => (
+            <NavLink
+              key={item.path}
+              to={item.path}
+              end={item.end}
+              className={({ isActive }) =>
+                cn(
+                  'flex items-center rounded-lg transition-colors',
+                  isCollapsed ? 'justify-center px-2 py-3' : 'gap-3 px-4 py-3',
+                  isActive ? 'bg-blue-600 text-white' : 'text-gray-300 hover:bg-gray-800'
+                )
+              }
+              title={isCollapsed ? item.label : undefined}
+            >
+              <item.icon className="w-5 h-5 flex-shrink-0" />
+              {!isCollapsed && <span>{item.label}</span>}
+            </NavLink>
+          ))}
+        </nav>
+      </aside>
+
+      <div
+        className={cn(
+          'flex-1 flex flex-col overflow-hidden transition-all duration-300 ease-in-out',
+          isCollapsed ? 'ml-20' : 'ml-64'
+        )}
+      >
+        <header className="bg-white border-b border-gray-200 px-6 py-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-gray-900">Platform Admin</h2>
+            <UserMenu />
+          </div>
+        </header>
+        <main className="flex-1 overflow-y-auto overflow-x-hidden p-6">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/layout/PlatformLayout.tsx
+++ b/frontend/src/components/layout/PlatformLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { NavLink, Outlet } from 'react-router-dom';
 import {
   LayoutDashboard,
@@ -9,6 +9,7 @@ import {
 } from 'lucide-react';
 import { cn } from '../../utils/cn';
 import { UserMenu } from '../common/UserMenu';
+import { useSidebarCollapse } from '../../hooks/useSidebarCollapse';
 
 const navItems = [
   { path: '/', icon: LayoutDashboard, label: 'Dashboard', end: true },
@@ -17,14 +18,7 @@ const navItems = [
 ];
 
 export const PlatformLayout: React.FC = () => {
-  const [isCollapsed, setIsCollapsed] = useState(() => {
-    const saved = localStorage.getItem('platformSidebarCollapsed');
-    return saved ? JSON.parse(saved) : false;
-  });
-
-  useEffect(() => {
-    localStorage.setItem('platformSidebarCollapsed', JSON.stringify(isCollapsed));
-  }, [isCollapsed]);
+  const [isCollapsed, setIsCollapsed] = useSidebarCollapse('platformSidebarCollapsed');
 
   return (
     <div className="flex h-screen bg-gray-50">

--- a/frontend/src/hooks/useSidebarCollapse.ts
+++ b/frontend/src/hooks/useSidebarCollapse.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect, useRef } from 'react';
+
+export function useSidebarCollapse(storageKey: string): [boolean, (next: boolean | ((prev: boolean) => boolean)) => void] {
+  const [isCollapsed, setIsCollapsed] = useState<boolean>(() => {
+    const saved = localStorage.getItem(storageKey);
+    return saved ? JSON.parse(saved) : false;
+  });
+
+  const isInitialMount = useRef(true);
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+    localStorage.setItem(storageKey, JSON.stringify(isCollapsed));
+  }, [isCollapsed, storageKey]);
+
+  return [isCollapsed, setIsCollapsed];
+}


### PR DESCRIPTION
## Summary
- Fixes platform.codadminpro.com rendering pages with no sidebar/nav (now wraps platform subdomain routes in a dedicated PlatformLayout)
- Adds backend/scripts/create-platform-admin.ts (env-driven or interactive, promote-or-create) — closes the bootstrap gap that required direct SQL
- CORS in server.ts now auto-derives platform.<host> from FRONTEND_URL so a missing PLATFORM_URL env can never silently break platform.* logins again
- Refactor: extract shared utilities (corsOrigins, scripts/lib/prompts, useSidebarCollapse) — 67 net lines removed, no behavior change

## Test plan
- [x] Backend build (npm run build) — clean
- [x] Backend unit tests — 784/784 pass
- [x] Frontend build — clean
- [x] Frontend tests — 71/71 pass
- [x] CORS unit tests cover auto-derive + explicit-override + localhost-guard + invalid-URL — 11/11 pass
- [x] Local browser QA on platform subdomain (VITE_PLATFORM_DOMAIN=localhost) — sidebar renders, all 3 nav routes work, active highlighting correct, console clean
- [ ] Integration tests on CI (need real DB; failed locally because Docker not running — env-only)
- [ ] Verify on staging.codadminpro.com platform subdomain after this lands
- [ ] Verify on platform.codadminpro.com after develop → main lands

## Notes
- Prod backend already has PLATFORM_URL=https://platform.codadminpro.com set as a hotfix env var (applied earlier today). With the auto-derive code, that env var becomes redundant but harmless — explicit PLATFORM_URL still wins when set.
- michael@codadminpro.com platform admin row was inserted directly via SQL during the hotfix; future bootstraps should use \`npm run create-platform-admin\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)