### PR TITLE
fix(platform): domain-aware login redirects

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { CustomerRepOnboarding, OnboardingWelcomeModal } from './components/onbo
 import { useIsMobile } from './hooks/useIsMobile';
 import { DESKTOP_FLAG, MOBILE_OPT_IN } from './constants/mobile';
 import { useConfigStore } from './stores/configStore';
+import { isPlatformDomain, platformLoginPath } from './utils/platformDomain';
 
 // Eager load authentication pages (critical path)
 import { Login } from './pages/Login';
@@ -86,12 +87,6 @@ const RoleGuard: React.FC<{ children: React.ReactNode; allowedRoles: string[] }>
   return <>{children}</>;
 };
 
-const PLATFORM_DOMAIN = import.meta.env.VITE_PLATFORM_DOMAIN || 'platform.codadminpro.com';
-
-function isPlatformDomain(): boolean {
-  return window.location.hostname === PLATFORM_DOMAIN;
-}
-
 // Wraps a platform admin page with guard + suspense for use in the tenant domain tree
 const platformRoute = (Component: React.ComponentType) => (
   <PlatformGuard>
@@ -103,7 +98,7 @@ const PlatformGuard: React.FC<{ children: React.ReactNode }> = ({ children }) =>
   const { isAuthenticated, user } = useAuthStore();
 
   if (!isAuthenticated || !user?.isPlatformAdmin) {
-    return <Navigate to={isPlatformDomain() ? '/login' : '/platform/login'} replace />;
+    return <Navigate to={platformLoginPath()} replace />;
   }
 
   return <>{children}</>;

--- a/frontend/src/components/common/UserMenu.tsx
+++ b/frontend/src/components/common/UserMenu.tsx
@@ -4,6 +4,7 @@ import { useAuthStore } from '../../stores/authStore';
 import { useNavigate } from 'react-router-dom';
 import { Dropdown, DropdownItem } from '../ui/Dropdown';
 import { Avatar } from '../ui/Avatar';
+import { platformLoginPath } from '../../utils/platformDomain';
 
 export const UserMenu: React.FC = () => {
   const { user, logout } = useAuthStore();
@@ -13,7 +14,7 @@ export const UserMenu: React.FC = () => {
 
   const handleLogout = () => {
     logout();
-    navigate(isPlatformAdmin ? '/platform/login' : '/login');
+    navigate(isPlatformAdmin ? platformLoginPath() : '/login');
   };
 
   return (

--- a/frontend/src/pages/PlatformLogin.tsx
+++ b/frontend/src/pages/PlatformLogin.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Eye, EyeOff } from 'lucide-react';
 import { useAuthStore } from '../stores/authStore';
 import toast from 'react-hot-toast';
+import { platformDashboardPath } from '../utils/platformDomain';
 
 export const PlatformLogin: React.FC = () => {
   const [email, setEmail] = useState('');
@@ -11,10 +12,10 @@ export const PlatformLogin: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const { login, user, isAuthenticated } = useAuthStore();
   const navigate = useNavigate();
+  const dashboardPath = platformDashboardPath();
 
-  // If already logged in as platform admin, redirect
   if (isAuthenticated && (user as any)?.isPlatformAdmin) {
-    navigate('/platform', { replace: true });
+    navigate(dashboardPath, { replace: true });
     return null;
   }
 
@@ -23,15 +24,13 @@ export const PlatformLogin: React.FC = () => {
     setLoading(true);
     try {
       await login({ email, password });
-      // Check if the logged-in user is a platform admin
       const state = useAuthStore.getState();
       if (!(state.user as any)?.isPlatformAdmin) {
-        // Not a platform admin, logout and show error
         useAuthStore.getState().logout();
         toast.error('Access denied. Platform admin credentials required.');
         return;
       }
-      navigate('/platform', { replace: true });
+      navigate(dashboardPath, { replace: true });
     } catch {
       toast.error('Invalid credentials');
     } finally {

--- a/frontend/src/utils/platformDomain.ts
+++ b/frontend/src/utils/platformDomain.ts
@@ -1,0 +1,23 @@
+const PLATFORM_DOMAIN = import.meta.env.VITE_PLATFORM_DOMAIN || 'platform.codadminpro.com';
+
+export function isPlatformDomain(): boolean {
+  return window.location.hostname === PLATFORM_DOMAIN;
+}
+
+/**
+ * Where the platform admin dashboard lives, depending on which domain we're on.
+ * - platform.codadminpro.com → '/'   (platform subdomain has its own router tree)
+ * - codadminpro.com          → '/platform'  (platform tree mounted under /platform)
+ */
+export function platformDashboardPath(): string {
+  return isPlatformDomain() ? '/' : '/platform';
+}
+
+/**
+ * Where the platform admin login lives.
+ * - platform.codadminpro.com → '/login'
+ * - codadminpro.com          → '/platform/login'
+ */
+export function platformLoginPath(): string {
+  return isPlatformDomain() ? '/login' : '/platform/login';
+}


### PR DESCRIPTION
## Summary
After PR #200 deployed, login on platform.codadminpro.com landed on a blank page. PlatformLogin navigated to '/platform' which doesn't exist on the platform subdomain — the dashboard route is '/'. Same shape in PlatformGuard and UserMenu logout.

## Fix
New \`utils/platformDomain.ts\` with:
- \`isPlatformDomain()\` — unchanged hostname check (was duplicated in App.tsx)
- \`platformDashboardPath()\` — '/' on platform subdomain, '/platform' on tenant
- \`platformLoginPath()\` — '/login' on platform subdomain, '/platform/login' on tenant

Three callsites now domain-aware: PlatformLogin authed-user guard, PlatformLogin post-login redirect, UserMenu logout redirect, and PlatformGuard unauthed redirect.

## Test plan
- [x] Frontend build clean
- [x] Frontend tests pass (71/71)
- [ ] Verify login → dashboard works on platform.codadminpro.com after merge → main
- [ ] Verify logout returns to platform login (not 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)