### PR TITLE
fix(platform): tenant pages — domain-aware navigation

### DIFF
--- a/frontend/src/pages/PlatformTenantDetail.tsx
+++ b/frontend/src/pages/PlatformTenantDetail.tsx
@@ -7,6 +7,7 @@ import { Modal } from '../components/ui/Modal';
 import { Input } from '../components/ui/Input';
 import { StatCard } from '../components/common/StatCard';
 import { usePlatformStore } from '../stores/platformStore';
+import { platformPath } from '../utils/platformDomain';
 
 const statusBadgeVariant = (status: string): 'success' | 'danger' | 'default' | 'warning' => {
   if (status === 'active') return 'success';
@@ -92,7 +93,7 @@ export const PlatformTenantDetail: React.FC = () => {
     setDeleting(true);
     try {
       await deleteTenant(id, currentTenant.slug);
-      navigate('/platform/tenants');
+      navigate(platformPath('tenants'));
     } finally {
       setDeleting(false);
     }
@@ -109,7 +110,7 @@ export const PlatformTenantDetail: React.FC = () => {
   if (!currentTenant) {
     return (
       <div className="space-y-4">
-        <Link to="/platform/tenants" className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline">
+        <Link to={platformPath('tenants')} className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline">
           <ArrowLeft className="w-4 h-4" /> Back to Tenants
         </Link>
         <p className="text-gray-500">Tenant not found.</p>
@@ -123,7 +124,7 @@ export const PlatformTenantDetail: React.FC = () => {
     <div className="space-y-6">
       {/* Back */}
       <Link
-        to="/platform/tenants"
+        to={platformPath('tenants')}
         className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"
       >
         <ArrowLeft className="w-4 h-4" /> Back to Tenants

--- a/frontend/src/pages/PlatformTenants.tsx
+++ b/frontend/src/pages/PlatformTenants.tsx
@@ -8,6 +8,7 @@ import { Input } from '../components/ui/Input';
 import { Select } from '../components/ui/Select';
 import { Pagination } from '../components/ui/Pagination';
 import { usePlatformStore } from '../stores/platformStore';
+import { platformPath } from '../utils/platformDomain';
 
 const PLAN_OPTIONS = [
   { value: '', label: 'All Plans' },
@@ -192,7 +193,7 @@ export const PlatformTenants: React.FC = () => {
                       <tr
                         key={t.id}
                         className="hover:bg-gray-50 cursor-pointer"
-                        onClick={() => navigate(`/platform/tenants/${t.id}`)}
+                        onClick={() => navigate(platformPath(`tenants/${t.id}`))}
                       >
                         <td className="px-4 py-3 text-sm font-medium text-gray-900">{t.name}</td>
                         <td className="px-4 py-3 text-sm text-gray-500 font-mono">{t.slug}</td>
@@ -217,7 +218,7 @@ export const PlatformTenants: React.FC = () => {
                           <button
                             onClick={(e) => {
                               e.stopPropagation();
-                              navigate(`/platform/tenants/${t.id}`);
+                              navigate(platformPath(`tenants/${t.id}`));
                             }}
                             className="text-blue-600 hover:text-blue-800 text-xs font-medium"
                           >

--- a/frontend/src/utils/platformDomain.ts
+++ b/frontend/src/utils/platformDomain.ts
@@ -21,3 +21,17 @@ export function platformDashboardPath(): string {
 export function platformLoginPath(): string {
   return isPlatformDomain() ? '/login' : '/platform/login';
 }
+
+/**
+ * Build a path inside the platform admin tree, prefixed correctly per domain.
+ *   platformPath('tenants')        → '/tenants' or '/platform/tenants'
+ *   platformPath(`tenants/${id}`)  → '/tenants/123' or '/platform/tenants/123'
+ *   platformPath('')               → '/' or '/platform'
+ */
+export function platformPath(suffix: string): string {
+  const cleaned = suffix.replace(/^\/+/, '');
+  if (isPlatformDomain()) {
+    return cleaned ? `/${cleaned}` : '/';
+  }
+  return cleaned ? `/platform/${cleaned}` : '/platform';
+}


### PR DESCRIPTION
Fixes blank page when clicking View on a tenant from platform.codadminpro.com. Five hardcoded '/platform/tenants' URLs in PlatformTenants and PlatformTenantDetail now use the new platformPath() helper from utils/platformDomain.ts.

Tenant tree (codadminpro.com/platform/...) is unaffected — its Sidebar still uses /platform/... directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)