### PR TITLE
release: user reactivation fix

### DIFF
--- a/backend/src/__tests__/unit/prismaExtensions.test.ts
+++ b/backend/src/__tests__/unit/prismaExtensions.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import bcrypt from 'bcrypt';
+import prisma from '../../utils/prisma';
+import { withSoftDeleted } from '../../utils/prismaExtensions';
+
+describe('softDeleteExtension', () => {
+  let activeId: number;
+  let inactiveId: number;
+  let tenantId: string;
+
+  beforeAll(async () => {
+    const tenant = await prisma.tenant.create({
+      data: { name: `Test ${Date.now()}`, slug: `t-soft-${Date.now()}` } as any,
+    } as any);
+    tenantId = tenant.id;
+    const pwd = await bcrypt.hash('test', 10);
+    const stamp = Date.now();
+    const active = await prisma.user.create({
+      data: {
+        email: `active-${stamp}@codadmin.test`, password: pwd,
+        firstName: 'A', lastName: 'A', role: 'sales_rep' as any,
+        isActive: true, tenantId,
+      } as any,
+    });
+    const inactive = await prisma.user.create({
+      data: {
+        email: `inactive-${stamp}@codadmin.test`, password: pwd,
+        firstName: 'I', lastName: 'I', role: 'sales_rep' as any,
+        isActive: false, tenantId,
+      } as any,
+    });
+    activeId = active.id;
+    inactiveId = inactive.id;
+  });
+
+  afterAll(async () => {
+    await prisma.user.deleteMany({ where: { id: { in: [activeId, inactiveId] } } } as any);
+    await prisma.tenant.delete({ where: { id: tenantId } } as any);
+  });
+
+  it('hides inactive users from findUnique by default', async () => {
+    const u = await prisma.user.findUnique({ where: { id: inactiveId } });
+    expect(u).toBeNull();
+  });
+
+  it('returns inactive users from findUnique inside withSoftDeleted', async () => {
+    const u = await withSoftDeleted(() => prisma.user.findUnique({ where: { id: inactiveId } }));
+    expect(u).not.toBeNull();
+    expect(u!.id).toBe(inactiveId);
+    expect(u!.isActive).toBe(false);
+  });
+
+  it('still returns active users from findUnique inside withSoftDeleted', async () => {
+    const u = await withSoftDeleted(() => prisma.user.findUnique({ where: { id: activeId } }));
+    expect(u).not.toBeNull();
+    expect(u!.id).toBe(activeId);
+  });
+
+  it('reverts to filtering after the withSoftDeleted scope ends', async () => {
+    await withSoftDeleted(() => prisma.user.findUnique({ where: { id: inactiveId } }));
+    const u = await prisma.user.findUnique({ where: { id: inactiveId } });
+    expect(u).toBeNull();
+  });
+
+  it('keeps findMany + count consistent inside withSoftDeleted', async () => {
+    const [list, total] = await withSoftDeleted(() => Promise.all([
+      prisma.user.findMany({ where: { id: { in: [activeId, inactiveId] } } as any }),
+      prisma.user.count({ where: { id: { in: [activeId, inactiveId] } } as any }),
+    ]));
+    expect(list.length).toBe(2);
+    expect(total).toBe(2);
+  });
+
+  it('still hides inactive users from findMany without withSoftDeleted', async () => {
+    const list = await prisma.user.findMany({ where: { id: { in: [activeId, inactiveId] } } as any });
+    expect(list.length).toBe(1);
+    expect(list[0].id).toBe(activeId);
+  });
+});

--- a/backend/src/controllers/adminController.ts
+++ b/backend/src/controllers/adminController.ts
@@ -67,12 +67,8 @@ export const getAllUsers = async (req: AuthRequest, res: Response, next: NextFun
     const page = parseInt(req.query.page as string) || 1;
     const limit = parseInt(req.query.limit as string) || 20;
     const role = req.query.role as any;
-    const isActiveRaw = req.query.isActive as string | undefined;
-    const isActive: boolean | 'all' | undefined =
-      isActiveRaw === 'true' ? true :
-      isActiveRaw === 'false' ? false :
-      isActiveRaw === 'all' ? 'all' :
-      undefined;
+    const ACTIVE_FILTER = { true: true, false: false, all: 'all' } as const;
+    const isActive = ACTIVE_FILTER[req.query.isActive as keyof typeof ACTIVE_FILTER];
 
     const result = await adminService.getAllUsers(req.user!, page, limit, role, isActive);
     res.json(result);

--- a/backend/src/controllers/adminController.ts
+++ b/backend/src/controllers/adminController.ts
@@ -2,6 +2,8 @@ import { Response, NextFunction } from 'express';
 import { AuthRequest } from '../types';
 import { adminService } from '../services/adminService';
 
+const ACTIVE_FILTER = { true: true, false: false, all: 'all' } as const;
+
 export const getSystemConfig = async (req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
   try {
     const config = await adminService.getSystemConfig(req.user);
@@ -67,7 +69,6 @@ export const getAllUsers = async (req: AuthRequest, res: Response, next: NextFun
     const page = parseInt(req.query.page as string) || 1;
     const limit = parseInt(req.query.limit as string) || 20;
     const role = req.query.role as any;
-    const ACTIVE_FILTER = { true: true, false: false, all: 'all' } as const;
     const isActive = ACTIVE_FILTER[req.query.isActive as keyof typeof ACTIVE_FILTER];
 
     const result = await adminService.getAllUsers(req.user!, page, limit, role, isActive);

--- a/backend/src/controllers/adminController.ts
+++ b/backend/src/controllers/adminController.ts
@@ -67,7 +67,12 @@ export const getAllUsers = async (req: AuthRequest, res: Response, next: NextFun
     const page = parseInt(req.query.page as string) || 1;
     const limit = parseInt(req.query.limit as string) || 20;
     const role = req.query.role as any;
-    const isActive = req.query.isActive === 'true' ? true : req.query.isActive === 'false' ? false : undefined;
+    const isActiveRaw = req.query.isActive as string | undefined;
+    const isActive: boolean | 'all' | undefined =
+      isActiveRaw === 'true' ? true :
+      isActiveRaw === 'false' ? false :
+      isActiveRaw === 'all' ? 'all' :
+      undefined;
 
     const result = await adminService.getAllUsers(req.user!, page, limit, role, isActive);
     res.json(result);

--- a/backend/src/services/adminService.ts
+++ b/backend/src/services/adminService.ts
@@ -1,4 +1,5 @@
 import prisma from '../utils/prisma';
+import { INCLUDE_SOFT_DELETED } from '../utils/prismaExtensions';
 import bcrypt from 'bcrypt';
 import { UserRole } from '@prisma/client';
 import { AppError } from '../middleware/errorHandler';
@@ -383,9 +384,7 @@ export const adminService = {
 
     const where: any = {};
     if (role) where.role = role;
-    // 'all' uses the soft-delete extension's null sentinel to bypass
-    // auto-injection of `isActive: true`.
-    if (isActive === 'all') where.isActive = null;
+    if (isActive === 'all') where[INCLUDE_SOFT_DELETED] = true;
     else if (typeof isActive === 'boolean') where.isActive = isActive;
 
     const [users, total] = await Promise.all([
@@ -490,11 +489,10 @@ export const adminService = {
   }) {
     await this.checkAdminPrivilege(requester, 'admin');
 
-    // findFirst with the soft-delete extension's null sentinel so inactive
-    // users aren't hidden from this lookup — admins must be able to
-    // reactivate them.
-    const targetUser = await prisma.user.findFirst({
-      where: { id: userId, isActive: null as any },
+    // INCLUDE_SOFT_DELETED bypasses the soft-delete auto-inject so this
+    // lookup can find inactive users (admins must be able to reactivate them).
+    const targetUser = await prisma.user.findUnique({
+      where: { id: userId, [INCLUDE_SOFT_DELETED]: true } as any,
       select: { role: true }
     });
 

--- a/backend/src/services/adminService.ts
+++ b/backend/src/services/adminService.ts
@@ -1,5 +1,5 @@
 import prisma from '../utils/prisma';
-import { INCLUDE_SOFT_DELETED } from '../utils/prismaExtensions';
+import { withSoftDeleted } from '../utils/prismaExtensions';
 import bcrypt from 'bcrypt';
 import { UserRole } from '@prisma/client';
 import { AppError } from '../middleware/errorHandler';
@@ -384,10 +384,9 @@ export const adminService = {
 
     const where: any = {};
     if (role) where.role = role;
-    if (isActive === 'all') where[INCLUDE_SOFT_DELETED] = true;
-    else if (typeof isActive === 'boolean') where.isActive = isActive;
+    if (typeof isActive === 'boolean') where.isActive = isActive;
 
-    const [users, total] = await Promise.all([
+    const fetchUsers = () => Promise.all([
       prisma.user.findMany({
         where,
         skip,
@@ -412,6 +411,10 @@ export const adminService = {
       }),
       prisma.user.count({ where }),
     ]);
+
+    const [users, total] = isActive === 'all'
+      ? await withSoftDeleted(fetchUsers)
+      : await fetchUsers();
 
     return {
       users,
@@ -489,12 +492,12 @@ export const adminService = {
   }) {
     await this.checkAdminPrivilege(requester, 'admin');
 
-    // INCLUDE_SOFT_DELETED bypasses the soft-delete auto-inject so this
-    // lookup can find inactive users (admins must be able to reactivate them).
-    const targetUser = await prisma.user.findUnique({
-      where: { id: userId, [INCLUDE_SOFT_DELETED]: true } as any,
+    // withSoftDeleted bypasses the soft-delete auto-inject so this lookup
+    // can find inactive users — admins must be able to reactivate them.
+    const targetUser = await withSoftDeleted(() => prisma.user.findUnique({
+      where: { id: userId },
       select: { role: true }
-    });
+    }));
 
     if (!targetUser) {
       throw new AppError('User not found', 404);

--- a/backend/src/services/adminService.ts
+++ b/backend/src/services/adminService.ts
@@ -377,13 +377,16 @@ export const adminService = {
   },
 
   // User Management
-  async getAllUsers(requester: Requester, page = 1, limit = 20, role?: UserRole, isActive?: boolean) {
+  async getAllUsers(requester: Requester, page = 1, limit = 20, role?: UserRole, isActive?: boolean | 'all') {
     await this.checkAdminPrivilege(requester, 'admin');
     const skip = (page - 1) * limit;
 
     const where: any = {};
     if (role) where.role = role;
-    if (typeof isActive === 'boolean') where.isActive = isActive;
+    // 'all' uses the soft-delete extension's null sentinel to bypass
+    // auto-injection of `isActive: true`.
+    if (isActive === 'all') where.isActive = null;
+    else if (typeof isActive === 'boolean') where.isActive = isActive;
 
     const [users, total] = await Promise.all([
       prisma.user.findMany({
@@ -487,8 +490,11 @@ export const adminService = {
   }) {
     await this.checkAdminPrivilege(requester, 'admin');
 
-    const targetUser = await prisma.user.findUnique({
-      where: { id: userId },
+    // findFirst with the soft-delete extension's null sentinel so inactive
+    // users aren't hidden from this lookup — admins must be able to
+    // reactivate them.
+    const targetUser = await prisma.user.findFirst({
+      where: { id: userId, isActive: null as any },
       select: { role: true }
     });
 

--- a/backend/src/utils/prismaExtensions.ts
+++ b/backend/src/utils/prismaExtensions.ts
@@ -152,36 +152,32 @@ export const tenantIsolationExtension = Prisma.defineExtension({
 const SOFT_DELETE_IS_ACTIVE = new Set(['User', 'Customer', 'Product', 'CheckoutForm', 'Automation']);
 const SOFT_DELETE_DELETED_AT = new Set(['Order']);
 
+// Out-of-band marker on a Prisma `where` clause that opts the caller out
+// of the auto-injected soft-delete filter. Symbol keys are invisible to
+// Prisma's serializer (it walks string keys via Object.keys), so they pass
+// through findUnique's strict input validation without affecting the SQL
+// — the extension strips the marker before calling query().
+export const INCLUDE_SOFT_DELETED = Symbol.for('codadmin.includeSoftDeleted');
+
 // Auto-inject the soft-delete filter only when the caller hasn't already
 // expressed an intent for that field — otherwise an admin endpoint that
 // wants to list inactive rows can never see them. Shallow check by design;
-// callers using AND/OR composites must opt out of the auto-inject themselves.
-//
-// Sentinel: passing `isActive: null` (for IS_ACTIVE models) means "include
-// both active and inactive rows" — the extension drops the field before the
-// query runs. Same convention applies to `deletedAt: 'all'` for DELETED_AT
-// models.
+// callers using AND/OR composites must opt out via INCLUDE_SOFT_DELETED.
 function applySoftDeleteFilter(model: string, args: { where?: any }) {
-  if (SOFT_DELETE_IS_ACTIVE.has(model)) {
-    const w = args.where as any;
-    if (w && w.isActive === null) {
-      const { isActive, ...rest } = w;
-      args.where = rest;
-      return;
-    }
-    if (w?.isActive === undefined) {
-      args.where = { ...args.where, isActive: true };
-    }
-  } else if (SOFT_DELETE_DELETED_AT.has(model)) {
-    const w = args.where as any;
-    if (w && w.deletedAt === 'all') {
-      const { deletedAt, ...rest } = w;
-      args.where = rest;
-      return;
-    }
-    if (w?.deletedAt === undefined) {
-      args.where = { ...args.where, deletedAt: null };
-    }
+  const isActiveModel = SOFT_DELETE_IS_ACTIVE.has(model);
+  const deletedAtModel = !isActiveModel && SOFT_DELETE_DELETED_AT.has(model);
+  if (!isActiveModel && !deletedAtModel) return;
+
+  const w = args.where as any;
+  if (w && w[INCLUDE_SOFT_DELETED]) {
+    delete w[INCLUDE_SOFT_DELETED];
+    return;
+  }
+
+  if (isActiveModel) {
+    if (w?.isActive === undefined) args.where = { ...w, isActive: true };
+  } else {
+    if (w?.deletedAt === undefined) args.where = { ...w, deletedAt: null };
   }
 }
 

--- a/backend/src/utils/prismaExtensions.ts
+++ b/backend/src/utils/prismaExtensions.ts
@@ -1,4 +1,5 @@
 import { Prisma } from '@prisma/client';
+import { AsyncLocalStorage } from 'async_hooks';
 import { getTenantId } from './tenantContext';
 
 // Models that carry a tenantId column and need automatic scoping
@@ -152,28 +153,41 @@ export const tenantIsolationExtension = Prisma.defineExtension({
 const SOFT_DELETE_IS_ACTIVE = new Set(['User', 'Customer', 'Product', 'CheckoutForm', 'Automation']);
 const SOFT_DELETE_DELETED_AT = new Set(['Order']);
 
-// Out-of-band marker on a Prisma `where` clause that opts the caller out
-// of the auto-injected soft-delete filter. Symbol keys are invisible to
-// Prisma's serializer (it walks string keys via Object.keys), so they pass
-// through findUnique's strict input validation without affecting the SQL
-// — the extension strips the marker before calling query().
-export const INCLUDE_SOFT_DELETED = Symbol('codadmin.includeSoftDeleted');
+// AsyncLocalStorage scope for opting out of the soft-delete auto-inject.
+// Symbol keys on `args.where` would not survive Prisma's extension framework
+// (they're stripped before reaching the hook), so a context-based mechanism
+// is required. Same pattern as tenantContext.ts.
+const softDeleteStorage = new AsyncLocalStorage<{ skip: boolean }>();
+
+/**
+ * Run `fn` in a scope where the soft-delete extension does not auto-inject
+ * its filter. Use this for admin lookups that must see inactive/deleted
+ * rows (e.g. reactivating a deactivated user).
+ *
+ * Tenant-isolation auto-inject is unaffected.
+ *
+ * Implementation note: AsyncLocalStorage.run only preserves the store for
+ * the synchronous portion of its callback. If `fn` is a sync arrow that
+ * returns a Promise, the store is reset before that Promise's continuations
+ * run — so the Prisma extension hook sees `undefined`. Wrapping in an async
+ * function keeps the scope alive until the inner promise resolves.
+ */
+export function withSoftDeleted<T>(fn: () => Promise<T>): Promise<T> {
+  return softDeleteStorage.run({ skip: true }, async () => fn());
+}
 
 // Auto-inject the soft-delete filter only when the caller hasn't already
 // expressed an intent for that field — otherwise an admin endpoint that
 // wants to list inactive rows can never see them. Shallow check by design;
-// callers using AND/OR composites must opt out via INCLUDE_SOFT_DELETED.
+// callers using AND/OR composites must opt out via withSoftDeleted().
 function applySoftDeleteFilter(model: string, args: { where?: any }) {
+  if (softDeleteStorage.getStore()?.skip) return;
+
   const isActiveModel = SOFT_DELETE_IS_ACTIVE.has(model);
   const deletedAtModel = !isActiveModel && SOFT_DELETE_DELETED_AT.has(model);
   if (!isActiveModel && !deletedAtModel) return;
 
   const w = args.where as any;
-  if (w && w[INCLUDE_SOFT_DELETED]) {
-    delete w[INCLUDE_SOFT_DELETED];
-    return;
-  }
-
   if (isActiveModel) {
     if (w?.isActive === undefined) args.where = { ...w, isActive: true };
   } else {

--- a/backend/src/utils/prismaExtensions.ts
+++ b/backend/src/utils/prismaExtensions.ts
@@ -157,7 +157,7 @@ const SOFT_DELETE_DELETED_AT = new Set(['Order']);
 // Prisma's serializer (it walks string keys via Object.keys), so they pass
 // through findUnique's strict input validation without affecting the SQL
 // — the extension strips the marker before calling query().
-export const INCLUDE_SOFT_DELETED = Symbol.for('codadmin.includeSoftDeleted');
+export const INCLUDE_SOFT_DELETED = Symbol('codadmin.includeSoftDeleted');
 
 // Auto-inject the soft-delete filter only when the caller hasn't already
 // expressed an intent for that field — otherwise an admin endpoint that
@@ -234,6 +234,10 @@ export const softDeleteExtension = Prisma.defineExtension({
         return query(args);
       },
       async findMany({ model, args, query }) {
+        applySoftDeleteFilter(model, args);
+        return query(args);
+      },
+      async count({ model, args, query }) {
         applySoftDeleteFilter(model, args);
         return query(args);
       },

--- a/backend/src/utils/prismaExtensions.ts
+++ b/backend/src/utils/prismaExtensions.ts
@@ -152,6 +152,39 @@ export const tenantIsolationExtension = Prisma.defineExtension({
 const SOFT_DELETE_IS_ACTIVE = new Set(['User', 'Customer', 'Product', 'CheckoutForm', 'Automation']);
 const SOFT_DELETE_DELETED_AT = new Set(['Order']);
 
+// Auto-inject the soft-delete filter only when the caller hasn't already
+// expressed an intent for that field — otherwise an admin endpoint that
+// wants to list inactive rows can never see them. Shallow check by design;
+// callers using AND/OR composites must opt out of the auto-inject themselves.
+//
+// Sentinel: passing `isActive: null` (for IS_ACTIVE models) means "include
+// both active and inactive rows" — the extension drops the field before the
+// query runs. Same convention applies to `deletedAt: 'all'` for DELETED_AT
+// models.
+function applySoftDeleteFilter(model: string, args: { where?: any }) {
+  if (SOFT_DELETE_IS_ACTIVE.has(model)) {
+    const w = args.where as any;
+    if (w && w.isActive === null) {
+      const { isActive, ...rest } = w;
+      args.where = rest;
+      return;
+    }
+    if (w?.isActive === undefined) {
+      args.where = { ...args.where, isActive: true };
+    }
+  } else if (SOFT_DELETE_DELETED_AT.has(model)) {
+    const w = args.where as any;
+    if (w && w.deletedAt === 'all') {
+      const { deletedAt, ...rest } = w;
+      args.where = rest;
+      return;
+    }
+    if (w?.deletedAt === undefined) {
+      args.where = { ...args.where, deletedAt: null };
+    }
+  }
+}
+
 export const softDeleteExtension = Prisma.defineExtension({
   name: 'softDelete',
   query: {
@@ -197,33 +230,15 @@ export const softDeleteExtension = Prisma.defineExtension({
         return query(args);
       },
       async findUnique({ model, args, query }) {
-
-        if (SOFT_DELETE_IS_ACTIVE.has(model)) {
-          args.where = { ...args.where, isActive: true } as any;
-        } else if (SOFT_DELETE_DELETED_AT.has(model)) {
-          args.where = { ...args.where, deletedAt: null } as any;
-        }
-
+        applySoftDeleteFilter(model, args);
         return query(args);
       },
       async findFirst({ model, args, query }) {
-
-        if (SOFT_DELETE_IS_ACTIVE.has(model)) {
-          args.where = { ...args.where, isActive: true } as any;
-        } else if (SOFT_DELETE_DELETED_AT.has(model)) {
-          args.where = { ...args.where, deletedAt: null } as any;
-        }
-
+        applySoftDeleteFilter(model, args);
         return query(args);
       },
       async findMany({ model, args, query }) {
-
-        if (SOFT_DELETE_IS_ACTIVE.has(model)) {
-          args.where = { ...args.where, isActive: true } as any;
-        } else if (SOFT_DELETE_DELETED_AT.has(model)) {
-          args.where = { ...args.where, deletedAt: null } as any;
-        }
-
+        applySoftDeleteFilter(model, args);
         return query(args);
       },
     },

--- a/frontend/src/components/admin/UserManagementTable.tsx
+++ b/frontend/src/components/admin/UserManagementTable.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Plus, Edit2, Trash2, RefreshCw, Search, Key, Eye, EyeOff } from 'lucide-react';
+import { Plus, Edit2, Trash2, RefreshCw, Search, Key, Eye, EyeOff, RotateCcw } from 'lucide-react';
 import { Button } from '../ui/Button';
 import { Card } from '../ui/Card';
 import { adminService, AdminUser, CreateUserData } from '../../services/admin.service';
@@ -25,6 +25,7 @@ export const UserManagementTable: React.FC = () => {
   const [selectedUser, setSelectedUser] = useState<AdminUser | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [roleFilter, setRoleFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'active' | 'inactive' | 'all'>('active');
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [totalUsers, setTotalUsers] = useState(0);
@@ -46,13 +47,14 @@ export const UserManagementTable: React.FC = () => {
 
   useEffect(() => {
     fetchUsers();
-  }, [roleFilter, currentPage]);
+  }, [roleFilter, statusFilter, currentPage]);
 
   const fetchUsers = async () => {
     try {
       setLoading(true);
       const response = await adminService.getUsers({
         role: roleFilter || undefined,
+        isActive: statusFilter === 'all' ? 'all' : statusFilter === 'active',
         page: currentPage,
         limit: 20,
       });
@@ -148,6 +150,15 @@ export const UserManagementTable: React.FC = () => {
     }
   };
 
+  const handleReactivate = async (user: AdminUser) => {
+    try {
+      await adminService.updateUser(user.id, { isActive: true });
+      fetchUsers();
+    } catch (error) {
+      console.error('Failed to reactivate user:', error);
+    }
+  };
+
   const openEditModal = (user: AdminUser) => {
     setSelectedUser(user);
     setFormData({
@@ -201,6 +212,18 @@ export const UserManagementTable: React.FC = () => {
             {USER_ROLES.map(role => (
               <option key={role.value} value={role.value}>{role.label}</option>
             ))}
+          </select>
+          <select
+            value={statusFilter}
+            onChange={(e) => {
+              setStatusFilter(e.target.value as 'active' | 'inactive' | 'all');
+              setCurrentPage(1);
+            }}
+            className="px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="active">Active</option>
+            <option value="inactive">Inactive</option>
+            <option value="all">All Statuses</option>
           </select>
         </div>
         <Button variant="primary" onClick={() => setShowCreateModal(true)}>
@@ -272,15 +295,26 @@ export const UserManagementTable: React.FC = () => {
                     >
                       <Key className="w-4 h-4 inline" />
                     </button>
-                    <button
-                      onClick={() => {
-                        setSelectedUser(user);
-                        setShowDeleteModal(true);
-                      }}
-                      className="text-red-600 hover:text-red-900"
-                    >
-                      <Trash2 className="w-4 h-4 inline" />
-                    </button>
+                    {user.isActive ? (
+                      <button
+                        onClick={() => {
+                          setSelectedUser(user);
+                          setShowDeleteModal(true);
+                        }}
+                        className="text-red-600 hover:text-red-900"
+                        title="Deactivate or delete user"
+                      >
+                        <Trash2 className="w-4 h-4 inline" />
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => handleReactivate(user)}
+                        className="text-green-600 hover:text-green-900"
+                        title="Reactivate user"
+                      >
+                        <RotateCcw className="w-4 h-4 inline" />
+                      </button>
+                    )}
                   </td>
                 </tr>
               ))}

--- a/frontend/src/components/admin/UserManagementTable.tsx
+++ b/frontend/src/components/admin/UserManagementTable.tsx
@@ -15,6 +15,8 @@ const USER_ROLES = [
   { value: 'accountant', label: 'Accountant' },
 ];
 
+const STATUS_TO_API = { active: true, inactive: false, all: 'all' as const };
+
 export const UserManagementTable: React.FC = () => {
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [loading, setLoading] = useState(true);
@@ -52,7 +54,6 @@ export const UserManagementTable: React.FC = () => {
   const fetchUsers = async () => {
     try {
       setLoading(true);
-      const STATUS_TO_API = { active: true, inactive: false, all: 'all' as const };
       const response = await adminService.getUsers({
         role: roleFilter || undefined,
         isActive: STATUS_TO_API[statusFilter],

--- a/frontend/src/components/admin/UserManagementTable.tsx
+++ b/frontend/src/components/admin/UserManagementTable.tsx
@@ -52,9 +52,10 @@ export const UserManagementTable: React.FC = () => {
   const fetchUsers = async () => {
     try {
       setLoading(true);
+      const STATUS_TO_API = { active: true, inactive: false, all: 'all' as const };
       const response = await adminService.getUsers({
         role: roleFilter || undefined,
-        isActive: statusFilter === 'all' ? 'all' : statusFilter === 'active',
+        isActive: STATUS_TO_API[statusFilter],
         page: currentPage,
         limit: 20,
       });

--- a/frontend/src/services/admin.service.ts
+++ b/frontend/src/services/admin.service.ts
@@ -149,7 +149,7 @@ export const adminService = {
     page?: number;
     limit?: number;
     role?: string;
-    isActive?: boolean;
+    isActive?: boolean | 'all';
   }): Promise<{
     users: AdminUser[];
     total: number;


### PR DESCRIPTION
Promotes #206 (now merged on develop) to production.

## What's in this release

Fixes the soft-delete Prisma extension that was making deactivated users invisible and irrecoverable through the admin UI. After merge, admins can:
- Filter the User Management table by status (Active default / Inactive / All)
- Reactivate a deactivated user via a green icon on inactive rows

Full detail in #206.

## Verification

- All CI checks green on develop (`7ac1a40`)
- Local pre-push validation: lints, builds, 60/62 backend test suites (867/879 tests) pass
- Suggested staging smoke before merge: hit https://staging.codadminpro.com → Settings → User Management → switch Status filter to Inactive → confirm previously-deactivated users appear → click green Reactivate icon → confirm flip works

## Test plan

- [ ] Active filter (default) shows the same users it did pre-release
- [ ] Inactive filter surfaces previously-deactivated users (e.g., Precious Adjei) with a red Inactive badge
- [ ] Green Reactivate icon flips status to Active
- [ ] Login by a deactivated user is still rejected (regression check on the soft-delete auto-inject)

🤖 Generated with [Claude Code](https://claude.com/claude-code)