### PR TITLE
fix(users): replace broken Symbol bypass with AsyncLocalStorage

### DIFF
--- a/backend/src/__tests__/unit/prismaExtensions.test.ts
+++ b/backend/src/__tests__/unit/prismaExtensions.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import bcrypt from 'bcrypt';
+import prisma from '../../utils/prisma';
+import { withSoftDeleted } from '../../utils/prismaExtensions';
+
+describe('softDeleteExtension', () => {
+  let activeId: number;
+  let inactiveId: number;
+  let tenantId: string;
+
+  beforeAll(async () => {
+    const tenant = await prisma.tenant.create({
+      data: { name: `Test ${Date.now()}`, slug: `t-soft-${Date.now()}` } as any,
+    } as any);
+    tenantId = tenant.id;
+    const pwd = await bcrypt.hash('test', 10);
+    const stamp = Date.now();
+    const active = await prisma.user.create({
+      data: {
+        email: `active-${stamp}@codadmin.test`, password: pwd,
+        firstName: 'A', lastName: 'A', role: 'sales_rep' as any,
+        isActive: true, tenantId,
+      } as any,
+    });
+    const inactive = await prisma.user.create({
+      data: {
+        email: `inactive-${stamp}@codadmin.test`, password: pwd,
+        firstName: 'I', lastName: 'I', role: 'sales_rep' as any,
+        isActive: false, tenantId,
+      } as any,
+    });
+    activeId = active.id;
+    inactiveId = inactive.id;
+  });
+
+  afterAll(async () => {
+    await prisma.user.deleteMany({ where: { id: { in: [activeId, inactiveId] } } } as any);
+    await prisma.tenant.delete({ where: { id: tenantId } } as any);
+  });
+
+  it('hides inactive users from findUnique by default', async () => {
+    const u = await prisma.user.findUnique({ where: { id: inactiveId } });
+    expect(u).toBeNull();
+  });
+
+  it('returns inactive users from findUnique inside withSoftDeleted', async () => {
+    const u = await withSoftDeleted(() => prisma.user.findUnique({ where: { id: inactiveId } }));
+    expect(u).not.toBeNull();
+    expect(u!.id).toBe(inactiveId);
+    expect(u!.isActive).toBe(false);
+  });
+
+  it('still returns active users from findUnique inside withSoftDeleted', async () => {
+    const u = await withSoftDeleted(() => prisma.user.findUnique({ where: { id: activeId } }));
+    expect(u).not.toBeNull();
+    expect(u!.id).toBe(activeId);
+  });
+
+  it('reverts to filtering after the withSoftDeleted scope ends', async () => {
+    await withSoftDeleted(() => prisma.user.findUnique({ where: { id: inactiveId } }));
+    const u = await prisma.user.findUnique({ where: { id: inactiveId } });
+    expect(u).toBeNull();
+  });
+
+  it('keeps findMany + count consistent inside withSoftDeleted', async () => {
+    const [list, total] = await withSoftDeleted(() => Promise.all([
+      prisma.user.findMany({ where: { id: { in: [activeId, inactiveId] } } as any }),
+      prisma.user.count({ where: { id: { in: [activeId, inactiveId] } } as any }),
+    ]));
+    expect(list.length).toBe(2);
+    expect(total).toBe(2);
+  });
+
+  it('still hides inactive users from findMany without withSoftDeleted', async () => {
+    const list = await prisma.user.findMany({ where: { id: { in: [activeId, inactiveId] } } as any });
+    expect(list.length).toBe(1);
+    expect(list[0].id).toBe(activeId);
+  });
+});

--- a/backend/src/services/adminService.ts
+++ b/backend/src/services/adminService.ts
@@ -1,5 +1,5 @@
 import prisma from '../utils/prisma';
-import { INCLUDE_SOFT_DELETED } from '../utils/prismaExtensions';
+import { withSoftDeleted } from '../utils/prismaExtensions';
 import bcrypt from 'bcrypt';
 import { UserRole } from '@prisma/client';
 import { AppError } from '../middleware/errorHandler';
@@ -384,10 +384,9 @@ export const adminService = {
 
     const where: any = {};
     if (role) where.role = role;
-    if (isActive === 'all') where[INCLUDE_SOFT_DELETED] = true;
-    else if (typeof isActive === 'boolean') where.isActive = isActive;
+    if (typeof isActive === 'boolean') where.isActive = isActive;
 
-    const [users, total] = await Promise.all([
+    const fetchUsers = () => Promise.all([
       prisma.user.findMany({
         where,
         skip,
@@ -412,6 +411,10 @@ export const adminService = {
       }),
       prisma.user.count({ where }),
     ]);
+
+    const [users, total] = isActive === 'all'
+      ? await withSoftDeleted(fetchUsers)
+      : await fetchUsers();
 
     return {
       users,
@@ -489,12 +492,12 @@ export const adminService = {
   }) {
     await this.checkAdminPrivilege(requester, 'admin');
 
-    // INCLUDE_SOFT_DELETED bypasses the soft-delete auto-inject so this
-    // lookup can find inactive users (admins must be able to reactivate them).
-    const targetUser = await prisma.user.findUnique({
-      where: { id: userId, [INCLUDE_SOFT_DELETED]: true } as any,
+    // withSoftDeleted bypasses the soft-delete auto-inject so this lookup
+    // can find inactive users — admins must be able to reactivate them.
+    const targetUser = await withSoftDeleted(() => prisma.user.findUnique({
+      where: { id: userId },
       select: { role: true }
-    });
+    }));
 
     if (!targetUser) {
       throw new AppError('User not found', 404);

--- a/backend/src/utils/prismaExtensions.ts
+++ b/backend/src/utils/prismaExtensions.ts
@@ -1,4 +1,5 @@
 import { Prisma } from '@prisma/client';
+import { AsyncLocalStorage } from 'async_hooks';
 import { getTenantId } from './tenantContext';
 
 // Models that carry a tenantId column and need automatic scoping
@@ -152,28 +153,41 @@ export const tenantIsolationExtension = Prisma.defineExtension({
 const SOFT_DELETE_IS_ACTIVE = new Set(['User', 'Customer', 'Product', 'CheckoutForm', 'Automation']);
 const SOFT_DELETE_DELETED_AT = new Set(['Order']);
 
-// Out-of-band marker on a Prisma `where` clause that opts the caller out
-// of the auto-injected soft-delete filter. Symbol keys are invisible to
-// Prisma's serializer (it walks string keys via Object.keys), so they pass
-// through findUnique's strict input validation without affecting the SQL
-// — the extension strips the marker before calling query().
-export const INCLUDE_SOFT_DELETED = Symbol('codadmin.includeSoftDeleted');
+// AsyncLocalStorage scope for opting out of the soft-delete auto-inject.
+// Symbol keys on `args.where` would not survive Prisma's extension framework
+// (they're stripped before reaching the hook), so a context-based mechanism
+// is required. Same pattern as tenantContext.ts.
+const softDeleteStorage = new AsyncLocalStorage<{ skip: boolean }>();
+
+/**
+ * Run `fn` in a scope where the soft-delete extension does not auto-inject
+ * its filter. Use this for admin lookups that must see inactive/deleted
+ * rows (e.g. reactivating a deactivated user).
+ *
+ * Tenant-isolation auto-inject is unaffected.
+ *
+ * Implementation note: AsyncLocalStorage.run only preserves the store for
+ * the synchronous portion of its callback. If `fn` is a sync arrow that
+ * returns a Promise, the store is reset before that Promise's continuations
+ * run — so the Prisma extension hook sees `undefined`. Wrapping in an async
+ * function keeps the scope alive until the inner promise resolves.
+ */
+export function withSoftDeleted<T>(fn: () => Promise<T>): Promise<T> {
+  return softDeleteStorage.run({ skip: true }, async () => fn());
+}
 
 // Auto-inject the soft-delete filter only when the caller hasn't already
 // expressed an intent for that field — otherwise an admin endpoint that
 // wants to list inactive rows can never see them. Shallow check by design;
-// callers using AND/OR composites must opt out via INCLUDE_SOFT_DELETED.
+// callers using AND/OR composites must opt out via withSoftDeleted().
 function applySoftDeleteFilter(model: string, args: { where?: any }) {
+  if (softDeleteStorage.getStore()?.skip) return;
+
   const isActiveModel = SOFT_DELETE_IS_ACTIVE.has(model);
   const deletedAtModel = !isActiveModel && SOFT_DELETE_DELETED_AT.has(model);
   if (!isActiveModel && !deletedAtModel) return;
 
   const w = args.where as any;
-  if (w && w[INCLUDE_SOFT_DELETED]) {
-    delete w[INCLUDE_SOFT_DELETED];
-    return;
-  }
-
   if (isActiveModel) {
     if (w?.isActive === undefined) args.where = { ...w, isActive: true };
   } else {


### PR DESCRIPTION
## Summary

Fixes the Reactivate button which returned 404 "User not found" on staging after #206 merged.

The Symbol-based opt-out from the soft-delete extension never actually worked: **Prisma's extension framework strips Symbol-keyed properties from `args.where` before passing them to the hook**, so the bypass branch in `applySoftDeleteFilter` never fired. Confirmed via SQL output — the wrapped `findUnique` emitted `WHERE id = $1 AND is_active = $2 [params: 95, true]`, meaning the auto-inject ran.

Replaces the Symbol mechanism with an `AsyncLocalStorage` scope, same pattern as `tenantContext.ts`. Callers wrap admin lookups in `withSoftDeleted(...)` and the extension reads from the store.

### Subtle gotcha worth flagging

`AsyncLocalStorage.run(store, fn)` only preserves the store for the **synchronous** body of `fn`. A sync arrow that returns a Promise exits the store before the Promise's continuations run, and Prisma's extension hook fires outside the scope. The fix wraps the caller's `fn` in an `async` function inside `withSoftDeleted` so the scope stays alive across the awaited call.

```ts
// Wrong (looks fine, doesn't work):
softDeleteStorage.run({ skip: true }, fn);

// Right:
softDeleteStorage.run({ skip: true }, async () => fn());
```

## Test plan

- [x] New `prismaExtensions.test.ts` — 6 tests covering default behavior, bypass, scope cleanup, findMany+count consistency
- [x] Full backend suite: 61/63 suites pass, 873/885 tests (12 skipped baseline, 0 failures)
- [x] Backend + frontend lint clean
- [x] Backend + frontend build clean
- [ ] On staging after merge: switch User Management Status filter to Inactive → click green Reactivate icon → confirm flip works (this was the broken path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)