### PR TITLE
feat: webhook idempotency audit + WebhookEvent table (MAN-55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **[Payments]**: Paystack webhook idempotency via `WebhookEvent` table — duplicate deliveries deduped at DB layer with unique `(provider, event_type, reference)` constraint (MAN-55)
 - **[Communications]**: Full communications dashboard with message history, delivery stats, bulk messaging, template manager, and opt-out management (MAN-32)
 - **[Communications]**: Auto-cleanup queue for MessageLog records with 90-day retention (MAN-32)
 - **[Communications]**: Customer opt-out enforcement in WhatsApp and SMS messaging services (MAN-32)

--- a/backend/prisma/migrations/20260529130600_add_webhook_event_idempotency/migration.sql
+++ b/backend/prisma/migrations/20260529130600_add_webhook_event_idempotency/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "webhook_events" (
+    "id" SERIAL NOT NULL,
+    "provider" TEXT NOT NULL DEFAULT 'paystack',
+    "event_type" TEXT NOT NULL,
+    "reference" TEXT NOT NULL,
+    "payload_hash" TEXT NOT NULL,
+    "tenant_id" TEXT,
+    "received_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "webhook_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "webhook_events_provider_event_type_reference_key" ON "webhook_events"("provider", "event_type", "reference");
+
+-- CreateIndex
+CREATE INDEX "webhook_events_tenant_id_idx" ON "webhook_events"("tenant_id");
+
+-- CreateIndex
+CREATE INDEX "webhook_events_received_at_idx" ON "webhook_events"("received_at");
+
+-- AddForeignKey
+ALTER TABLE "webhook_events" ADD CONSTRAINT "webhook_events_tenant_id_fkey" FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -8,46 +8,47 @@ datasource db {
 }
 
 model Tenant {
-  id                  String    @id @default(uuid())
-  name                String
-  slug                String    @unique
-  logo                String?
-  region              String?
-  currency            String    @default("GHS")
-  defaultDeliveryFee  Float?    @map("default_delivery_fee")
-  currentPlanId       String?   @map("current_plan_id")
-  subscriptionStatus  String    @default("active") @map("subscription_status")
-  trialEndsAt         DateTime? @map("trial_ends_at")
-  rateLimitEnabled    Boolean   @default(false) @map("rate_limit_enabled")
-  rateLimitConfig     Json?     @map("rate_limit_config")
-  createdAt           DateTime  @default(now())
-  updatedAt           DateTime  @updatedAt
+  id                 String    @id @default(uuid())
+  name               String
+  slug               String    @unique
+  logo               String?
+  region             String?
+  currency           String    @default("GHS")
+  defaultDeliveryFee Float?    @map("default_delivery_fee")
+  currentPlanId      String?   @map("current_plan_id")
+  subscriptionStatus String    @default("active") @map("subscription_status")
+  trialEndsAt        DateTime? @map("trial_ends_at")
+  rateLimitEnabled   Boolean   @default(false) @map("rate_limit_enabled")
+  rateLimitConfig    Json?     @map("rate_limit_config")
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
 
   currentPlan Plan? @relation(fields: [currentPlanId], references: [id])
 
   // Reverse relations for tenant-scoped models
-  users              User[]
-  customers          Customer[]
-  products           Product[]
-  orders             Order[]
-  deliveries         Delivery[]
-  transactions       Transaction[]
-  expenses           Expense[]
-  accounts           Account[]
-  journalEntries     JournalEntry[]
+  users               User[]
+  customers           Customer[]
+  products            Product[]
+  orders              Order[]
+  deliveries          Delivery[]
+  transactions        Transaction[]
+  expenses            Expense[]
+  accounts            Account[]
+  journalEntries      JournalEntry[]
   accountTransactions AccountTransaction[]
-  workflows          Workflow[]
-  workflowExecutions WorkflowExecution[]
-  webhookConfigs     WebhookConfig[]
-  notifications      Notification[]
-  checkoutForms      CheckoutForm[]
-  inventoryShipments InventoryShipment[]
-  agentBalances      AgentBalance[]
-  inventoryTransfers InventoryTransfer[]
-  agentStocks        AgentStock[]
-  messageLogs        MessageLog[]
-  systemConfigs      SystemConfig[]
-  mcpApiKeys         McpApiKey[]
+  workflows           Workflow[]
+  workflowExecutions  WorkflowExecution[]
+  webhookConfigs      WebhookConfig[]
+  notifications       Notification[]
+  checkoutForms       CheckoutForm[]
+  inventoryShipments  InventoryShipment[]
+  agentBalances       AgentBalance[]
+  inventoryTransfers  InventoryTransfer[]
+  agentStocks         AgentStock[]
+  messageLogs         MessageLog[]
+  systemConfigs       SystemConfig[]
+  mcpApiKeys          McpApiKey[]
+  webhookEvents       WebhookEvent[]
 
   @@map("tenants")
 }
@@ -78,57 +79,57 @@ model PlatformAnnouncement {
   expiresAt DateTime? @map("expires_at")
   createdBy Int?      @map("created_by")
   createdAt DateTime  @default(now()) @map("created_at")
-  updatedAt DateTime  @updatedAt      @map("updated_at")
+  updatedAt DateTime  @updatedAt @map("updated_at")
 
   @@map("platform_announcements")
 }
 
 model User {
-  id                    Int               @id @default(autoincrement())
-  email                 String            @unique
+  id                    Int                 @id @default(autoincrement())
+  email                 String              @unique
   password              String
-  phoneNumber           String?           @map("phone_number")
+  phoneNumber           String?             @map("phone_number")
   role                  UserRole
-  isActive              Boolean           @default(true) @map("is_active")
-  isPlatformAdmin       Boolean           @default(false) @map("is_platform_admin")
-  isAvailable           Boolean           @default(true) @map("is_available")
-  lastLogin             DateTime?         @map("last_login")
-  refreshToken          String?           @map("refresh_token")
-  passwordResetToken    String?           @unique @map("password_reset_token")
-  passwordResetExpires  DateTime?         @map("password_reset_expires")
-  commissionAmount      Float?            @default(0) @map("commission_amount") /// Fixed commission amount per delivery (GHS)
+  isActive              Boolean             @default(true) @map("is_active")
+  isPlatformAdmin       Boolean             @default(false) @map("is_platform_admin")
+  isAvailable           Boolean             @default(true) @map("is_available")
+  lastLogin             DateTime?           @map("last_login")
+  refreshToken          String?             @map("refresh_token")
+  passwordResetToken    String?             @unique @map("password_reset_token")
+  passwordResetExpires  DateTime?           @map("password_reset_expires")
+  commissionAmount      Float?              @default(0) @map("commission_amount") /// Fixed commission amount per delivery (GHS)
   country               String?
   preferences           Json?
-  vehicleType           String?           @map("vehicle_type")
-  vehicleId             String?           @map("vehicle_id")
-  deliveryRate          Float?            @default(0) @map("delivery_rate")
-  totalEarnings         Float?            @default(0) @map("total_earnings")
-  totalCollected        Decimal           @default(0) @map("total_collected") @db.Decimal(19, 4)
+  vehicleType           String?             @map("vehicle_type")
+  vehicleId             String?             @map("vehicle_id")
+  deliveryRate          Float?              @default(0) @map("delivery_rate")
+  totalEarnings         Float?              @default(0) @map("total_earnings")
+  totalCollected        Decimal             @default(0) @map("total_collected") @db.Decimal(19, 4)
   location              String?
-  createdAt             DateTime          @default(now()) @map("created_at")
-  updatedAt             DateTime          @updatedAt @map("updated_at")
-  firstName             String            @map("first_name")
-  lastName              String            @map("last_name")
-  calls                 Call[]            @relation("CallSalesRep")
+  createdAt             DateTime            @default(now()) @map("created_at")
+  updatedAt             DateTime            @updatedAt @map("updated_at")
+  firstName             String              @map("first_name")
+  lastName              String              @map("last_name")
+  calls                 Call[]              @relation("CallSalesRep")
   deliveries            Delivery[]
   expenses              Expense[]
   notifications         Notification[]
-  createdOrders         Order[]           @relation("OrderCreatedBy")
-  assignedOrdersAsRep   Order[]           @relation("OrderCustomerRep")
-  assignedOrdersAsAgent Order[]           @relation("OrderDeliveryAgent")
+  createdOrders         Order[]             @relation("OrderCreatedBy")
+  assignedOrdersAsRep   Order[]             @relation("OrderCustomerRep")
+  assignedOrdersAsAgent Order[]             @relation("OrderDeliveryAgent")
   payouts               Payout[]
   auditLogs             AuditLog[]
-  journalEntriesCreated JournalEntry[]    @relation("JournalEntryCreator")
-  journalEntriesVoided  JournalEntry[]    @relation("VoidedByUser")
-  collections           AgentCollection[] @relation("AgentCollections")
-  verifiedCollections   AgentCollection[] @relation("VerifiedCollections")
-  approvedCollections   AgentCollection[] @relation("ApprovedCollections")
+  journalEntriesCreated JournalEntry[]      @relation("JournalEntryCreator")
+  journalEntriesVoided  JournalEntry[]      @relation("VoidedByUser")
+  collections           AgentCollection[]   @relation("AgentCollections")
+  verifiedCollections   AgentCollection[]   @relation("VerifiedCollections")
+  approvedCollections   AgentCollection[]   @relation("ApprovedCollections")
   balance               AgentBalance?
-  deposits              AgentDeposit[]    @relation("AgentDeposits")
-  verifiedDeposits      AgentDeposit[]    @relation("VerifiedDeposits")
+  deposits              AgentDeposit[]      @relation("AgentDeposits")
+  verifiedDeposits      AgentDeposit[]      @relation("VerifiedDeposits")
   agingBucket           AgentAgingBucket?
-  blockedBalances       AgentBalance[]    @relation("BlockedBy")
-  agentStock            AgentStock[]      @relation("AgentStockHoldings")
+  blockedBalances       AgentBalance[]      @relation("BlockedBy")
+  agentStock            AgentStock[]        @relation("AgentStockHoldings")
   transfersFrom         InventoryTransfer[] @relation("TransferFrom")
   transfersTo           InventoryTransfer[] @relation("TransferTo")
   transfersCreated      InventoryTransfer[] @relation("TransferCreator")
@@ -143,25 +144,25 @@ model User {
 }
 
 model Customer {
-  id             Int      @id @default(autoincrement())
+  id             Int          @id @default(autoincrement())
   email          String?
-  phoneNumber    String   @map("phone_number")
-  alternatePhone String?  @map("alternate_phone")
+  phoneNumber    String       @map("phone_number")
+  alternatePhone String?      @map("alternate_phone")
   address        String
   state          String
   area           String
   landmark       String?
-  tags           String[] @default([])
+  tags           String[]     @default([])
   notes          String?
-  totalOrders    Int      @default(0) @map("total_orders")
-  totalSpent     Float    @default(0) @map("total_spent")
-  isActive       Boolean  @default(true) @map("is_active")
-  smsOptOut      Boolean  @default(false) @map("sms_opt_out")
-  whatsappOptOut Boolean  @default(false) @map("whatsapp_opt_out")
-  createdAt      DateTime @default(now()) @map("created_at")
-  updatedAt      DateTime @updatedAt @map("updated_at")
-  firstName      String   @map("first_name")
-  lastName       String   @map("last_name")
+  totalOrders    Int          @default(0) @map("total_orders")
+  totalSpent     Float        @default(0) @map("total_spent")
+  isActive       Boolean      @default(true) @map("is_active")
+  smsOptOut      Boolean      @default(false) @map("sms_opt_out")
+  whatsappOptOut Boolean      @default(false) @map("whatsapp_opt_out")
+  createdAt      DateTime     @default(now()) @map("created_at")
+  updatedAt      DateTime     @updatedAt @map("updated_at")
+  firstName      String       @map("first_name")
+  lastName       String       @map("last_name")
   calls          Call[]
   orders         Order[]
   messageLogs    MessageLog[]
@@ -178,36 +179,36 @@ model Customer {
 }
 
 model Product {
-  id                   Int                    @id @default(autoincrement())
-  sku                  String                 @unique
-  name                 String
-  description          String?
-  category             String
-  price                Float
-  stockQuantity        Int                    @map("stock_quantity")
-  lowStockThreshold    Int                    @default(10) @map("low_stock_threshold")
-  imageUrl             String?                @map("image_url")
-  weight               Float?
-  dimensions           Json?
-  isActive             Boolean                @default(true) @map("is_active")
-  createdAt            DateTime               @default(now()) @map("created_at")
-  updatedAt            DateTime               @updatedAt @map("updated_at")
-  batch_quantity       Int                    @default(1)
-  cogs                 Decimal?               @default(0) @db.Decimal(10, 2)
-  productType          String                 @default("physical") @map("product_type")
-  digitalFileUrl       String?                @map("digital_file_url")
-  digitalFileType      String?                @map("digital_file_type")
-  downloadLinkExpiryHours Int?                @default(72) @map("download_link_expiry_hours")
-  checkoutForms        CheckoutForm[]
-  formUpsells          FormUpsell[]
-  orderItems           OrderItem[]
-  product_cost_entries product_cost_entries[]
-  webhookConfigs       WebhookConfig[]
-  agentStock           AgentStock[]
-  inventoryTransfers   InventoryTransfer[]
-  inventoryShipments   InventoryShipment[]
-  tenantId             String?             @map("tenant_id")
-  tenant               Tenant?             @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  id                      Int                    @id @default(autoincrement())
+  sku                     String                 @unique
+  name                    String
+  description             String?
+  category                String
+  price                   Float
+  stockQuantity           Int                    @map("stock_quantity")
+  lowStockThreshold       Int                    @default(10) @map("low_stock_threshold")
+  imageUrl                String?                @map("image_url")
+  weight                  Float?
+  dimensions              Json?
+  isActive                Boolean                @default(true) @map("is_active")
+  createdAt               DateTime               @default(now()) @map("created_at")
+  updatedAt               DateTime               @updatedAt @map("updated_at")
+  batch_quantity          Int                    @default(1)
+  cogs                    Decimal?               @default(0) @db.Decimal(10, 2)
+  productType             String                 @default("physical") @map("product_type")
+  digitalFileUrl          String?                @map("digital_file_url")
+  digitalFileType         String?                @map("digital_file_type")
+  downloadLinkExpiryHours Int?                   @default(72) @map("download_link_expiry_hours")
+  checkoutForms           CheckoutForm[]
+  formUpsells             FormUpsell[]
+  orderItems              OrderItem[]
+  product_cost_entries    product_cost_entries[]
+  webhookConfigs          WebhookConfig[]
+  agentStock              AgentStock[]
+  inventoryTransfers      InventoryTransfer[]
+  inventoryShipments      InventoryShipment[]
+  tenantId                String?                @map("tenant_id")
+  tenant                  Tenant?                @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
   @@index([isActive])
   @@index([category, isActive])
@@ -218,59 +219,59 @@ model Product {
 }
 
 model Order {
-  id                Int              @id @default(autoincrement())
-  customerId        Int              @map("customer_id")
-  customerRepId     Int?             @map("customer_rep_id")
-  deliveryAgentId   Int?             @map("delivery_agent_id")
-  status            OrderStatus      @default(pending_confirmation)
-  paymentStatus     PaymentStatus    @default(pending) @map("payment_status")
-  subtotal          Float
-  shippingCost      Float            @default(0) @map("shipping_cost")
-  discount          Float            @default(0)
-  totalAmount       Float            @map("total_amount")
-  codAmount         Float?           @map("cod_amount")
-  notes             String?
-  internalNotes     String?          @map("internal_notes")
-  orderType         String           @default("physical") @map("order_type")
-  paymentMethod     String           @default("cod") @map("payment_method")
-  paymentReference  String?          @map("payment_reference")
-  deliveryAddress   String?          @map("delivery_address")
-  deliveryState     String?          @map("delivery_state")
-  deliveryArea      String?          @map("delivery_area")
-  estimatedDelivery DateTime?        @map("estimated_delivery")
-  priority          Int              @default(0)
-  tags              String[]         @default([])
-  source            String           @default("manual")
-  externalOrderId   String?          @map("external_order_id")
-  webhookData       Json?            @map("webhook_data")
-  webhookFingerprint String?         @unique @map("webhook_fingerprint")
-  createdById       Int?             @map("created_by_id")
-  createdAt         DateTime         @default(now()) @map("created_at")
-  updatedAt         DateTime         @updatedAt @map("updated_at")
-  deletedAt         DateTime?        @map("deleted_at")
-  commissionPaid    Boolean          @default(false) @map("commission_paid")
-  payoutId          Int?             @map("payout_id")
-  revenueRecognized Boolean          @default(false) @map("revenue_recognized")
-  glJournalEntryId  Int?             @map("gl_journal_entry_id")
-  deliveryDate      DateTime?        @map("delivery_date")
-  calls             Call[]
-  delivery          Delivery?
-  formSubmissions   FormSubmission[]
-  orderHistory      OrderHistory[]
-  orderItems          OrderItem[]
-  createdBy         User?            @relation("OrderCreatedBy", fields: [createdById], references: [id])
-  customer            Customer           @relation(fields: [customerId], references: [id])
-  customerRep         User?              @relation("OrderCustomerRep", fields: [customerRepId], references: [id])
-  deliveryAgent       User?              @relation("OrderDeliveryAgent", fields: [deliveryAgentId], references: [id])
-  transaction       Transaction?
-  payout            Payout?          @relation(fields: [payoutId], references: [id])
-  glJournalEntry    JournalEntry?    @relation(fields: [glJournalEntryId], references: [id])
-  agentCollection   AgentCollection?
+  id                 Int                 @id @default(autoincrement())
+  customerId         Int                 @map("customer_id")
+  customerRepId      Int?                @map("customer_rep_id")
+  deliveryAgentId    Int?                @map("delivery_agent_id")
+  status             OrderStatus         @default(pending_confirmation)
+  paymentStatus      PaymentStatus       @default(pending) @map("payment_status")
+  subtotal           Float
+  shippingCost       Float               @default(0) @map("shipping_cost")
+  discount           Float               @default(0)
+  totalAmount        Float               @map("total_amount")
+  codAmount          Float?              @map("cod_amount")
+  notes              String?
+  internalNotes      String?             @map("internal_notes")
+  orderType          String              @default("physical") @map("order_type")
+  paymentMethod      String              @default("cod") @map("payment_method")
+  paymentReference   String?             @map("payment_reference")
+  deliveryAddress    String?             @map("delivery_address")
+  deliveryState      String?             @map("delivery_state")
+  deliveryArea       String?             @map("delivery_area")
+  estimatedDelivery  DateTime?           @map("estimated_delivery")
+  priority           Int                 @default(0)
+  tags               String[]            @default([])
+  source             String              @default("manual")
+  externalOrderId    String?             @map("external_order_id")
+  webhookData        Json?               @map("webhook_data")
+  webhookFingerprint String?             @unique @map("webhook_fingerprint")
+  createdById        Int?                @map("created_by_id")
+  createdAt          DateTime            @default(now()) @map("created_at")
+  updatedAt          DateTime            @updatedAt @map("updated_at")
+  deletedAt          DateTime?           @map("deleted_at")
+  commissionPaid     Boolean             @default(false) @map("commission_paid")
+  payoutId           Int?                @map("payout_id")
+  revenueRecognized  Boolean             @default(false) @map("revenue_recognized")
+  glJournalEntryId   Int?                @map("gl_journal_entry_id")
+  deliveryDate       DateTime?           @map("delivery_date")
+  calls              Call[]
+  delivery           Delivery?
+  formSubmissions    FormSubmission[]
+  orderHistory       OrderHistory[]
+  orderItems         OrderItem[]
+  createdBy          User?               @relation("OrderCreatedBy", fields: [createdById], references: [id])
+  customer           Customer            @relation(fields: [customerId], references: [id])
+  customerRep        User?               @relation("OrderCustomerRep", fields: [customerRepId], references: [id])
+  deliveryAgent      User?               @relation("OrderDeliveryAgent", fields: [deliveryAgentId], references: [id])
+  transaction        Transaction?
+  payout             Payout?             @relation(fields: [payoutId], references: [id])
+  glJournalEntry     JournalEntry?       @relation(fields: [glJournalEntryId], references: [id])
+  agentCollection    AgentCollection?
   inventoryTransfers InventoryTransfer[]
-  messageLogs       MessageLog[]
-  downloadTokens    DownloadToken[]
-  tenantId          String?          @map("tenant_id")
-  tenant            Tenant?          @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  messageLogs        MessageLog[]
+  downloadTokens     DownloadToken[]
+  tenantId           String?             @map("tenant_id")
+  tenant             Tenant?             @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
   @@index([customerId])
   @@index([status])
@@ -574,6 +575,24 @@ model WebhookLog {
   @@map("webhook_logs")
 }
 
+// Inbound webhook idempotency ledger.
+// Insert before any side effect; unique violation = replay, ack and return.
+model WebhookEvent {
+  id          Int      @id @default(autoincrement())
+  provider    String   @default("paystack")
+  eventType   String   @map("event_type")
+  reference   String
+  payloadHash String   @map("payload_hash")
+  tenantId    String?  @map("tenant_id")
+  tenant      Tenant?  @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  receivedAt  DateTime @default(now()) @map("received_at")
+
+  @@unique([provider, eventType, reference], name: "provider_event_reference")
+  @@index([tenantId])
+  @@index([receivedAt])
+  @@map("webhook_events")
+}
+
 model Notification {
   id        Int      @id @default(autoincrement())
   userId    Int      @map("user_id")
@@ -769,29 +788,29 @@ model product_cost_entries {
 }
 
 model InventoryShipment {
-  id                  Int              @id @default(autoincrement())
-  productId           Int              @map("product_id")
+  id                  Int            @id @default(autoincrement())
+  productId           Int            @map("product_id")
   supplier            String?
   quantity            Int
-  unitCost            Decimal          @default(0) @map("unit_cost") @db.Decimal(10, 2)
-  shippingCost        Decimal          @default(0) @map("shipping_cost") @db.Decimal(10, 2)
-  customsDuties       Decimal          @default(0) @map("customs_duties") @db.Decimal(10, 2)
-  otherCosts          Decimal          @default(0) @map("other_costs") @db.Decimal(10, 2)
-  totalCost           Decimal          @default(0) @map("total_cost") @db.Decimal(10, 2)
-  status              ShipmentStatus   @default(pending)
-  expectedArrivalDate DateTime?        @map("expected_arrival_date")
-  arrivedAt           DateTime?        @map("arrived_at")
-  glJournalEntryId    Int?             @map("gl_journal_entry_id")
+  unitCost            Decimal        @default(0) @map("unit_cost") @db.Decimal(10, 2)
+  shippingCost        Decimal        @default(0) @map("shipping_cost") @db.Decimal(10, 2)
+  customsDuties       Decimal        @default(0) @map("customs_duties") @db.Decimal(10, 2)
+  otherCosts          Decimal        @default(0) @map("other_costs") @db.Decimal(10, 2)
+  totalCost           Decimal        @default(0) @map("total_cost") @db.Decimal(10, 2)
+  status              ShipmentStatus @default(pending)
+  expectedArrivalDate DateTime?      @map("expected_arrival_date")
+  arrivedAt           DateTime?      @map("arrived_at")
+  glJournalEntryId    Int?           @map("gl_journal_entry_id")
   notes               String?
-  createdById         Int              @map("created_by_id")
-  createdAt           DateTime         @default(now()) @map("created_at")
-  updatedAt           DateTime         @updatedAt @map("updated_at")
+  createdById         Int            @map("created_by_id")
+  createdAt           DateTime       @default(now()) @map("created_at")
+  updatedAt           DateTime       @updatedAt @map("updated_at")
 
-  product             Product          @relation(fields: [productId], references: [id], onDelete: Cascade)
-  createdBy           User             @relation("ShipmentCreator", fields: [createdById], references: [id])
-  glJournalEntry      JournalEntry?    @relation(fields: [glJournalEntryId], references: [id])
-  tenantId            String?          @map("tenant_id")
-  tenant              Tenant?          @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  product        Product       @relation(fields: [productId], references: [id], onDelete: Cascade)
+  createdBy      User          @relation("ShipmentCreator", fields: [createdById], references: [id])
+  glJournalEntry JournalEntry? @relation(fields: [glJournalEntryId], references: [id])
+  tenantId       String?       @map("tenant_id")
+  tenant         Tenant?       @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
   @@index([productId])
   @@index([status])
@@ -857,8 +876,8 @@ model AgentBalance {
   updatedAt          DateTime  @updatedAt @map("updated_at")
   tenantId           String?   @map("tenant_id")
 
-  agent     User  @relation(fields: [agentId], references: [id])
-  blockedBy User? @relation("BlockedBy", fields: [blockedById], references: [id])
+  agent     User    @relation(fields: [agentId], references: [id])
+  blockedBy User?   @relation("BlockedBy", fields: [blockedById], references: [id])
   tenant    Tenant? @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
   @@index([tenantId])
@@ -1110,15 +1129,15 @@ model AgentStock {
 }
 
 model DownloadToken {
-  id             Int      @id @default(autoincrement())
-  orderId        Int      @map("order_id")
-  token          String   @unique
-  expiresAt      DateTime @map("expires_at")
-  downloadCount  Int      @default(0) @map("download_count")
-  maxDownloads   Int      @default(5) @map("max_downloads")
-  isRevoked      Boolean  @default(false) @map("is_revoked")
-  createdAt      DateTime @default(now()) @map("created_at")
-  order          Order    @relation(fields: [orderId], references: [id])
+  id            Int      @id @default(autoincrement())
+  orderId       Int      @map("order_id")
+  token         String   @unique
+  expiresAt     DateTime @map("expires_at")
+  downloadCount Int      @default(0) @map("download_count")
+  maxDownloads  Int      @default(5) @map("max_downloads")
+  isRevoked     Boolean  @default(false) @map("is_revoked")
+  createdAt     DateTime @default(now()) @map("created_at")
+  order         Order    @relation(fields: [orderId], references: [id])
 
   @@index([token])
   @@index([orderId])

--- a/backend/src/__tests__/unit/paystackController.test.ts
+++ b/backend/src/__tests__/unit/paystackController.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { Prisma } from '@prisma/client';
+
+jest.mock('../../utils/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+}));
+
+jest.mock('../../services/paystackService', () => ({
+  paystackService: {
+    validateWebhookSignature: jest.fn(),
+    verifyTransaction: jest.fn(),
+  },
+}));
+
+jest.mock('../../services/digitalDeliveryService', () => ({
+  digitalDeliveryService: {
+    generateDownloadToken: jest.fn(),
+    sendDownloadLinks: jest.fn(),
+  },
+}));
+
+jest.mock('../../services/glAutomationService', () => ({
+  GLAutomationService: jest.fn().mockImplementation(() => ({
+    createDigitalSaleEntry: jest.fn(),
+  })),
+}));
+
+import { prismaMock } from '../mocks/prisma.mock';
+import * as paystackServiceModule from '../../services/paystackService';
+import { handleWebhook } from '../../controllers/paystackController';
+
+const mockedPaystack = paystackServiceModule.paystackService as jest.Mocked<
+  typeof paystackServiceModule.paystackService
+>;
+
+function buildReq(rawBody: string) {
+  return {
+    headers: { 'x-paystack-signature': 'sig-ok' },
+    body: JSON.parse(rawBody),
+    rawBody,
+  } as any;
+}
+
+function buildRes() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  } as any;
+}
+
+describe('paystackController.handleWebhook — idempotency', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedPaystack.validateWebhookSignature.mockResolvedValue(true);
+    mockedPaystack.verifyTransaction.mockResolvedValue({
+      data: {
+        status: 'success',
+        reference: 'ref_abc123',
+        amount: 240_00,
+        currency: 'GHS',
+        metadata: { orderId: 42 },
+      },
+    } as any);
+    (prismaMock.order.findUnique as any).mockResolvedValue({ tenantId: 'tenant-1' });
+    (prismaMock.$queryRaw as any).mockResolvedValue([{ id: 42 }]);
+    (prismaMock.$transaction as any).mockImplementation(async (cb: any) =>
+      typeof cb === 'function' ? cb(prismaMock) : cb,
+    );
+  });
+
+  it('dedupes (provider, eventType, reference) triplet across replays', async () => {
+    const payload = {
+      event: 'charge.success',
+      data: {
+        reference: 'ref_abc123',
+        amount: 240_00,
+        fees: 360,
+        currency: 'GHS',
+        metadata: { orderId: 42 },
+      },
+    };
+    const rawBody = JSON.stringify(payload);
+
+    // First call: clean insert.
+    (prismaMock.webhookEvent.create as any).mockResolvedValueOnce({
+      id: 1,
+      provider: 'paystack',
+      eventType: 'charge.success',
+      reference: 'ref_abc123',
+      payloadHash: 'h',
+      tenantId: 'tenant-1',
+      receivedAt: new Date(),
+    });
+
+    // Subsequent calls: unique constraint violation (P2002).
+    const p2002 = new Prisma.PrismaClientKnownRequestError('unique', {
+      code: 'P2002',
+      clientVersion: '5.22.0',
+    } as any);
+    (prismaMock.webhookEvent.create as any)
+      .mockRejectedValueOnce(p2002)
+      .mockRejectedValueOnce(p2002);
+
+    const r1 = buildRes();
+    const r2 = buildRes();
+    const r3 = buildRes();
+    await handleWebhook(buildReq(rawBody), r1);
+    await handleWebhook(buildReq(rawBody), r2);
+    await handleWebhook(buildReq(rawBody), r3);
+
+    // All 3 ACK with 200.
+    expect(r1.status).toHaveBeenCalledWith(200);
+    expect(r2.status).toHaveBeenCalledWith(200);
+    expect(r3.status).toHaveBeenCalledWith(200);
+
+    // First was a clean insert; replays were marked duplicate.
+    expect(r1.json).toHaveBeenCalledWith({ received: true });
+    expect(r2.json).toHaveBeenCalledWith({ received: true, duplicate: true });
+    expect(r3.json).toHaveBeenCalledWith({ received: true, duplicate: true });
+
+    // Side effects fired exactly once.
+    expect(mockedPaystack.verifyTransaction).toHaveBeenCalledTimes(1);
+    expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('processes a distinct reference independently', async () => {
+    const payloadA = {
+      event: 'charge.success',
+      data: { reference: 'ref_a', amount: 100_00, fees: 0, currency: 'GHS', metadata: { orderId: 42 } },
+    };
+    const payloadB = {
+      event: 'charge.success',
+      data: { reference: 'ref_b', amount: 100_00, fees: 0, currency: 'GHS', metadata: { orderId: 43 } },
+    };
+
+    (prismaMock.webhookEvent.create as any)
+      .mockResolvedValueOnce({} as any)
+      .mockResolvedValueOnce({} as any);
+
+    const rA = buildRes();
+    const rB = buildRes();
+    await handleWebhook(buildReq(JSON.stringify(payloadA)), rA);
+    await handleWebhook(buildReq(JSON.stringify(payloadB)), rB);
+
+    expect(rA.json).toHaveBeenCalledWith({ received: true });
+    expect(rB.json).toHaveBeenCalledWith({ received: true });
+    expect(mockedPaystack.verifyTransaction).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/src/controllers/paystackController.ts
+++ b/backend/src/controllers/paystackController.ts
@@ -1,4 +1,6 @@
 import { Request, Response } from 'express';
+import { createHash } from 'crypto';
+import { Prisma } from '@prisma/client';
 import { paystackService } from '../services/paystackService';
 import { digitalDeliveryService } from '../services/digitalDeliveryService';
 import { GLAutomationService } from '../services/glAutomationService';
@@ -35,6 +37,32 @@ export async function handleWebhook(req: Request, res: Response): Promise<void> 
     const event = req.body;
     logger.info('Paystack webhook received', { event: event.event });
 
+    // Idempotency gate: record (provider, event_type, reference) before any side effect.
+    // Unique-constraint violation = replay; ack and return without re-processing.
+    const reference: string | undefined = event?.data?.reference;
+    if (reference && event?.event) {
+      const payloadHash = createHash('sha256').update(rawBody).digest('hex');
+      const tenantId = await resolveTenantFromEvent(event);
+      try {
+        await prisma.webhookEvent.create({
+          data: {
+            provider: 'paystack',
+            eventType: event.event,
+            reference,
+            payloadHash,
+            tenantId,
+          },
+        });
+      } catch (err) {
+        if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+          logger.info('Paystack webhook replay ignored', { eventType: event.event, reference });
+          res.status(200).json({ received: true, duplicate: true });
+          return;
+        }
+        throw err;
+      }
+    }
+
     if (event.event === 'charge.success') {
       await handleChargeSuccess(event.data);
     }
@@ -54,6 +82,19 @@ interface PaystackChargeData {
   amount: number;
   fees: number;
   currency: string;
+}
+
+// Best-effort tenantId resolution from the event's metadata.orderId.
+// Returns null when the order can't be resolved — the dedup row is still useful.
+async function resolveTenantFromEvent(event: any): Promise<string | null> {
+  const raw = event?.data?.metadata?.orderId ?? event?.data?.metadata?.order_id;
+  const orderId = Number(raw);
+  if (!Number.isInteger(orderId) || orderId <= 0) return null;
+  const order = await prisma.order.findUnique({
+    where: { id: orderId },
+    select: { tenantId: true },
+  });
+  return order?.tenantId ?? null;
 }
 
 async function handleChargeSuccess(data: PaystackChargeData): Promise<void> {

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -11,6 +11,7 @@ Each file documents one feature area. Related Linear issues are appended as work
 | Cash Flow Report | [cash-flow-report.md](cash-flow-report.md) | Complete |
 | Bulk Orders | [bulk-orders.md](bulk-orders.md) | Planning |
 | Financial Module | [financial-module-prd.md](financial-module-prd.md) | PRD |
+| Paystack Checkout & Webhook Infrastructure | [paystack-checkout.md](paystack-checkout.md) | In Progress |
 
 ## Adding a new feature doc
 

--- a/docs/features/paystack-checkout.md
+++ b/docs/features/paystack-checkout.md
@@ -1,0 +1,29 @@
+# Paystack Checkout & Webhook Infrastructure
+
+Infrastructure for processing Paystack webhooks reliably and exposing checkout primitives to embedded host pages. This is the umbrella for the multi-issue payment-rebuild work (CODA-1..5 from the parent plan).
+
+Parent plan: `~/.claude/plans/i-want-to-improve-sleepy-sun.md`
+
+---
+
+## MAN-55 — Webhook idempotency audit + WebhookEvent table
+**Date:** 2026-05-29 | **Type:** feat | **Branch:** feature/man-55-webhook-idempotency | **Commit:** 69454b5
+
+### Summary
+Adds a `WebhookEvent` dedup table with a unique constraint on `(provider, event_type, reference)` and an INSERT-or-bail gate at the top of `paystackController.handleWebhook`. Duplicate webhook deliveries from Paystack (replays, retries, double-fires) are caught at the DB layer, acknowledged with `200 + duplicate:true`, and never re-trigger side effects. The pre-existing atomic `UPDATE ... WHERE payment_status != 'paid'` inside `handleChargeSuccess` is kept as a second-line defense (belt + suspenders).
+
+### Changes
+- **Backend:** New `WebhookEvent` Prisma model with unique constraint on `(provider, event_type, reference)`, nullable `tenant_id` FK to `Tenant`, SHA-256 `payload_hash` reserved for forensic audit. Gate inserted in `paystackController.handleWebhook` after HMAC verify, before any side effect: best-effort tenant resolution from `metadata.orderId`, then `prisma.webhookEvent.create`. P2002 catch returns duplicate ACK; non-P2002 errors re-throw to the existing 200-on-error stance.
+- **Frontend:** No changes (no UI surface).
+- **Database:** Migration `20260529130600_add_webhook_event_idempotency` adds `webhook_events` table with `SERIAL` PK, unique index on `(provider, event_type, reference)`, indices on `tenant_id` and `received_at`, and `CASCADE` FK to `tenants(id)`.
+
+### Key Files
+- `backend/prisma/schema.prisma` — new `WebhookEvent` model + `Tenant.webhookEvents` back-reference
+- `backend/prisma/migrations/20260529130600_add_webhook_event_idempotency/migration.sql` — hand-rolled SQL matching project SERIAL/CASCADE convention
+- `backend/src/controllers/paystackController.ts` — idempotency gate (lines 40–64) + `resolveTenantFromEvent` helper (lines 89–98) with `Number.isInteger && > 0` guard
+- `backend/src/__tests__/unit/paystackController.test.ts` — 2 tests: triplet dedup across 3 replays + distinct-reference independence
+
+### Verification
+- Replay the same `charge.success` payload 3× → 1st returns `{received:true}`, 2nd + 3rd return `{received:true, duplicate:true}`, `verifyTransaction` called once, atomic `UPDATE` runs once.
+- Two distinct references → both process independently, `verifyTransaction` called twice.
+- Malformed `metadata.orderId` (`"abc"`, `NaN`, empty, negative, decimal) → `resolveTenantFromEvent` returns `null` without crashing Prisma; dedup row still written with `tenant_id = NULL`.


### PR DESCRIPTION
## Summary
- Adds `WebhookEvent` dedup table with unique constraint on `(provider, event_type, reference)` and an INSERT-or-bail gate at the top of `paystackController.handleWebhook`. Duplicate Paystack deliveries are caught at the DB layer, acked with `200 + duplicate:true`, and never re-trigger side effects.
- Keeps the pre-existing atomic `UPDATE ... WHERE payment_status != 'paid'` inside `handleChargeSuccess` as a second-line defense (belt + suspenders).
- Best-effort `tenant_id` resolution from `metadata.orderId` with `Number.isInteger && > 0` guard so malformed payloads can't silently bypass the dedup write.

First issue (CODA-1) of the CodAdmin Embed Widget + Paystack Everywhere rebuild — foundation for CODA-2..6. Parent plan: `~/.claude/plans/i-want-to-improve-sleepy-sun.md`.

Closes MAN-55.

## Test plan
- [x] `backend/src/__tests__/unit/paystackController.test.ts` — `dedupes (provider, eventType, reference) triplet across replays` (3 identical posts → 1× `verifyTransaction`, 1× `$queryRaw UPDATE`)
- [x] `backend/src/__tests__/unit/paystackController.test.ts` — `processes a distinct reference independently` (2 different refs both process)
- [x] `npm run build` (tsc) — clean
- [x] `npm run lint` (eslint) — clean
- [x] `./scripts/validate-workflows.sh` — all 4 workflows valid
- [ ] CI runs the migration against staging Postgres on merge

## Notes for reviewer
- Migration was hand-rolled to match the existing project SERIAL/CASCADE convention (Postgres + Docker were offline locally). Verified syntactically against neighbouring migrations in `backend/prisma/migrations/`.
- /simplify (extra-high effort) surfaced 6 findings: 1 fix applied in this PR (NaN guard); 5 deliberately scoped out (state-machine recovery for CODA-2, future-event gate for CODA-6/7, non-P2002 re-throw semantics, forensic `payloadHash`, replay-side resolve query). Detail in the Linear comment.
- `prisma format` ran on `schema.prisma`; most of the schema diff is whitespace re-alignment — semantic changes are the new `WebhookEvent` model + `Tenant.webhookEvents` back-reference only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)