### PR TITLE
chore: Vite dev-server overlay for instant frontend HMR

### DIFF
--- a/docker-compose.vite.yml
+++ b/docker-compose.vite.yml
@@ -1,0 +1,63 @@
+# Vite dev-server overlay — instant HMR for the admin frontend, no image rebuilds.
+#
+# The default `frontend` service serves a production Nginx build, so every UI
+# source change needs a full image rebuild to show up. This overlay swaps in a
+# Vite dev server with Hot Module Replacement: edit a .tsx file and the browser
+# updates in ~1s, no rebuild.
+#
+# Usage (compose with the dev stack so backend/postgres/redis + network exist):
+#
+#   docker compose \
+#     -f docker-compose.dev.yml \
+#     -f docker-compose.dev.override.yml \
+#     -f docker-compose.vite.yml \
+#     -p codadmin up -d --build frontend-dev
+#
+# First run builds the `dev` Dockerfile stage (deps only — fast). After that,
+# code changes hot-reload with zero rebuilds. Open http://localhost:5173.
+#
+# Including this file gates the Nginx `frontend` behind the `nginx` profile, so
+# it won't start and fight over port 5173. To go back to the Nginx build, drop
+# this -f flag (or add `--profile nginx`).
+#
+# Caveats:
+# - This serves the ADMIN DASHBOARD with HMR. The embeddable widget (/embed.js)
+#   is a separate build artifact (`npm run build:embed`) and is NOT served by the
+#   Vite dev server — test the live widget against the Nginx build.
+# - Adding/removing an npm dependency means rebuilding the image and recreating
+#   the anonymous node_modules volume:
+#     docker compose ... -p codadmin up -d --build --force-recreate -V frontend-dev
+
+services:
+  # Disable the Nginx prod frontend whenever this overlay is active so it doesn't
+  # contend for host port 5173. It still runs in the default dev stack (this file
+  # absent), and can be forced on here with `--profile nginx`.
+  frontend:
+    profiles: ["nginx"]
+
+  frontend-dev:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      target: dev
+    container_name: ecommerce-frontend-dev-vite
+    restart: unless-stopped
+    ports:
+      - "5173:5173"
+    environment:
+      # Browser-side: the SPA talks to the host-mapped backend directly.
+      VITE_API_URL: http://localhost:3000
+      VITE_WS_URL: http://localhost:3000
+      # Server-side: Vite's /api + /uploads proxy reaches the backend container
+      # over the compose network (localhost:3000 wouldn't resolve in-container).
+      VITE_PROXY_TARGET: http://backend:3000
+    volumes:
+      # Live source mount for HMR...
+      - ./frontend:/app
+      # ...with an anonymous volume shadowing node_modules so the host's
+      # macOS-built deps never clobber the container's Linux-native ones.
+      - /app/node_modules
+    depends_on:
+      - backend
+    networks:
+      - ecommerce-dev-network

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -24,6 +24,23 @@ RUN npm run build
 # Build the standalone embed widget (dist-embed/embed.js), served at /embed.js
 RUN npm run build:embed
 
+# Dev stage — Vite dev server with HMR (no build; source is bind-mounted at runtime).
+# Only deps are baked in; the container's node_modules is preserved via an anonymous
+# volume in docker-compose.vite.yml so the host's macOS-built node_modules never
+# shadows the Linux-native ones (esbuild/terser are platform-specific).
+FROM node:20-alpine AS dev
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+# Source is provided by a bind mount at runtime; nothing else is copied in.
+EXPOSE 5173
+
+# --host 0.0.0.0 makes the dev server reachable from outside the container.
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
+
 # Production stage with Nginx
 FROM nginx:1.25-alpine AS production
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -60,12 +60,15 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
+      // VITE_PROXY_TARGET lets the dev server run inside Docker (target the
+      // `backend` service over the compose network) while defaulting to
+      // localhost:3000 for a plain host-run dev server.
       '/api': {
-        target: 'http://localhost:3000',
+        target: process.env.VITE_PROXY_TARGET || 'http://localhost:3000',
         changeOrigin: true,
       },
       '/uploads': {
-        target: 'http://localhost:3000',
+        target: process.env.VITE_PROXY_TARGET || 'http://localhost:3000',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## What

Adds an opt-in **Vite dev-server overlay** so admin-frontend UI changes show instantly via HMR — no Docker image rebuild per edit.

The default `frontend` service serves a production Nginx build (`target: production`), so every UI source change currently needs a full image rebuild to appear. This overlay swaps in a Vite dev server with Hot Module Replacement: edit a `.tsx` file and the browser updates in ~1s.

## Changes (3 files)

- **`frontend/Dockerfile`** — new `dev` stage (deps-only, runs `vite --host 0.0.0.0`), inserted before `production` so the default target is unchanged.
- **`docker-compose.vite.yml`** — opt-in overlay. Adds `frontend-dev` (build target `dev`, port `5173`, live `./frontend` bind-mount + anonymous `node_modules` volume so host macOS deps don't shadow the container's Linux-native esbuild/terser). Gates the Nginx `frontend` behind a `nginx` profile to avoid a port-5173 clash.
- **`frontend/vite.config.ts`** — `/api` and `/uploads` proxy target is now env-driven via `VITE_PROXY_TARGET` (defaults to `http://localhost:3000`, so plain host-run dev is unchanged); lets the dev server reach the `backend` service over the compose network when run in Docker.

## Usage

```bash
docker compose \
  -f docker-compose.dev.yml \
  -f docker-compose.dev.override.yml \
  -f docker-compose.vite.yml \
  -p codadmin up -d --build frontend-dev
# → http://localhost:5173 with HMR
```

## Notes / caveats

- This serves the **admin dashboard** with HMR. The embeddable widget (`/embed.js`) is a separate build artifact (`npm run build:embed`) and is **not** served by the Vite dev server — test the live widget against the Nginx build.
- Adding/removing an npm dep means rebuilding the image and recreating the anonymous `node_modules` volume (`--build --force-recreate -V frontend-dev`).
- Verified end-to-end: container up on 5173 → HTTP 200, edits to checkout-builder components HMR-reload in the browser.

## Verification

- `./scripts/validate-workflows.sh` — ✅ all workflows pass.
- Default `frontend` (Nginx production) path untouched; overlay is opt-in via the extra `-f` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
