### PR TITLE
fix(gl): stop orphaning account_transactions with NULL tenant_id

### DIFF
--- a/backend/prisma/migrations/20260630070000_require_account_transaction_tenant/migration.sql
+++ b/backend/prisma/migrations/20260630070000_require_account_transaction_tenant/migration.sql
@@ -1,0 +1,26 @@
+-- Repair + lock tenant_id on account_transactions.
+--
+-- Root cause: the Prisma tenant extension injects tenant_id only into the
+-- top-level create, never the nested transactions.create. Background GL writers
+-- (reconciliation cron / setImmediate) ran without AsyncLocalStorage context, so
+-- their account_transactions were written tenant_id = NULL and vanished from
+-- tenant-scoped financial reporting (June revenue read ~$200 instead of ~GHS 71k).
+--
+-- This migration is the historical repair AND the guardrail. Ordering matters:
+-- the backfill MUST clear every NULL before the column can be locked NOT NULL,
+-- so a dirty database can never silently pass this migration.
+
+-- Step 1: Backfill orphaned rows from their parent journal entry's tenant.
+-- The parent journal_entries are correctly tagged (verified: 100% coverage,
+-- single tenant), making this deterministic. Covers ALL source types
+-- (order_delivery, agent_collection, manual, etc.), not just revenue.
+UPDATE "account_transactions" AS at
+SET "tenant_id" = je."tenant_id"
+FROM "journal_entries" AS je
+WHERE at."journal_entry_id" = je."id"
+  AND at."tenant_id" IS NULL
+  AND je."tenant_id" IS NOT NULL;
+
+-- Step 2: Lock the column. Fails loudly (rolls back the whole migration) if any
+-- NULL remains — by design: a financial row with no tenant must never persist.
+ALTER TABLE "account_transactions" ALTER COLUMN "tenant_id" SET NOT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -501,8 +501,11 @@ model AccountTransaction {
   runningBalance Decimal  @default(0) @map("running_balance") @db.Decimal(19, 4)
   description    String?
   createdAt      DateTime @default(now()) @map("created_at")
-  tenantId       String?  @map("tenant_id")
-  tenant         Tenant?  @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  // Required: a NULL tenant makes the row invisible to tenant-scoped financial
+  // reporting (revenue silently vanishes). Backfilled from the parent journal
+  // entry and locked NOT NULL by migration 20260630070000.
+  tenantId       String   @map("tenant_id")
+  tenant         Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
   journalEntry JournalEntry @relation(fields: [journalEntryId], references: [id], onDelete: Cascade)
   account      Account      @relation(fields: [accountId], references: [id])

--- a/backend/src/__tests__/integration/agentBalance.test.ts
+++ b/backend/src/__tests__/integration/agentBalance.test.ts
@@ -5,6 +5,7 @@ import { GL_ACCOUNTS } from '../../config/glAccounts';
 import { AccountType, NormalBalance, Prisma } from '@prisma/client';
 import { Decimal } from '@prisma/client/runtime/library';
 import { GLAccountService } from '../../services/glAccountService';
+import { withGlTestTenant } from './helpers/glTestTenant';
 
 // Mock socket instance
 jest.mock('../../utils/socketInstance', () => ({
@@ -26,19 +27,22 @@ describe('Agent Balance and Deposit Integration', () => {
 
     beforeEach(async () => {
         GLAccountService.clearCache();
-        // Clean up - Order matters due to foreign keys
-        await prisma.accountTransaction.deleteMany({});
-        await (prisma as any).agentDeposit.deleteMany({});
-        await (prisma as any).agentCollection.deleteMany({});
-        await (prisma as any).agentBalance.deleteMany({});
-        await prisma.delivery.deleteMany({});
-        await prisma.orderItem.deleteMany({});
-        await prisma.order.deleteMany({});
-        await prisma.journalEntry.deleteMany({});
-        await prisma.customer.deleteMany({});
-        await prisma.account.deleteMany({});
-        await prisma.user.deleteMany({
-            where: { email: { in: ['admin@test.com', 'agent@test.com'] } }
+        // Unscoped cleanup, then seed + enter tenant context (mirrors a request).
+        await withGlTestTenant(async () => {
+            // Clean up - Order matters due to foreign keys
+            await prisma.accountTransaction.deleteMany({});
+            await (prisma as any).agentDeposit.deleteMany({});
+            await (prisma as any).agentCollection.deleteMany({});
+            await (prisma as any).agentBalance.deleteMany({});
+            await prisma.delivery.deleteMany({});
+            await prisma.orderItem.deleteMany({});
+            await prisma.order.deleteMany({});
+            await prisma.journalEntry.deleteMany({});
+            await prisma.customer.deleteMany({});
+            await prisma.account.deleteMany({});
+            await prisma.user.deleteMany({
+                where: { email: { in: ['admin@test.com', 'agent@test.com'] } }
+            });
         });
 
         // Setup GL Accounts

--- a/backend/src/__tests__/integration/agentBalanceConcurrency.test.ts
+++ b/backend/src/__tests__/integration/agentBalanceConcurrency.test.ts
@@ -3,22 +3,29 @@ import prisma from '../../utils/prisma';
 import agentReconciliationService from '../../services/agentReconciliationService';
 import { GL_ACCOUNTS } from '../../config/glAccounts';
 import { AccountType, NormalBalance, Prisma } from '@prisma/client';
+import { withGlTestTenant } from './helpers/glTestTenant';
+import { tenantStorage } from '../../utils/tenantContext';
 
 describe('Agent Balance Concurrency Integration Test', () => {
     let testUser: any;
     let testAgent: any;
+    let testTenantId: string;
 
     beforeAll(async () => {
-        // Clean up - Order matters due to foreign keys
-        await prisma.accountTransaction.deleteMany({});
-        await (prisma as any).agentDeposit.deleteMany({});
-        await (prisma as any).agentBalance.deleteMany({});
-        await prisma.journalEntry.deleteMany({});
-        await prisma.user.deleteMany({
-            where: { email: { in: ['admin-con@test.com', 'agent-con@test.com'] } }
+        // Unscoped cleanup, then seed + enter tenant context (mirrors a request).
+        testTenantId = await withGlTestTenant(async () => {
+            // Clean up - Order matters due to foreign keys
+            await prisma.accountTransaction.deleteMany({});
+            await (prisma as any).agentDeposit.deleteMany({});
+            await (prisma as any).agentBalance.deleteMany({});
+            await prisma.journalEntry.deleteMany({});
+            await prisma.account.deleteMany({});
+            await prisma.user.deleteMany({
+                where: { email: { in: ['admin-con@test.com', 'agent-con@test.com'] } }
+            });
         });
 
-        // Setup GL Accounts needed
+        // Setup GL Accounts needed (under tenant context so they're scoped)
         const accounts: Prisma.AccountUncheckedCreateInput[] = [
             { id: parseInt(GL_ACCOUNTS.AR_AGENTS), code: GL_ACCOUNTS.AR_AGENTS, name: 'Agent AR', accountType: AccountType.asset, normalBalance: NormalBalance.debit },
             { id: parseInt(GL_ACCOUNTS.CASH_IN_HAND), code: GL_ACCOUNTS.CASH_IN_HAND, name: 'Cash in Hand', accountType: AccountType.asset, normalBalance: NormalBalance.debit },
@@ -67,31 +74,35 @@ describe('Agent Balance Concurrency Integration Test', () => {
     });
 
     it('should maintain correct agent balance under concurrent deposit verifications', async () => {
-        // 1. Setup initial balance of 2000
-        const initialBalance = await agentReconciliationService.getOrCreateBalance(testAgent.id);
-        await (prisma as any).agentBalance.update({
-            where: { id: initialBalance.id },
-            data: { currentBalance: 2000 }
+        // restoreMocks wipes the beforeAll getTenantId spy before this test, so run
+        // the body inside real ALS tenant context (faithful to a live request).
+        await tenantStorage.run({ tenantId: testTenantId }, async () => {
+            // 1. Setup initial balance of 2000
+            const initialBalance = await agentReconciliationService.getOrCreateBalance(testAgent.id);
+            await (prisma as any).agentBalance.update({
+                where: { id: initialBalance.id },
+                data: { currentBalance: 2000 }
+            });
+
+            // 2. Create 5 deposits of 100 each
+            const depositIds: number[] = [];
+            for (let i = 0; i < 5; i++) {
+                const d = await agentReconciliationService.createDeposit(testAgent.id, 100, 'bank_transfer', `REF-CON-${i}`);
+                depositIds.push(d.id);
+            }
+
+            // 3. Verify all deposits concurrently
+            // Note: In a real scenario, different admins might verify them at the same time.
+            const promises = depositIds.map(id =>
+                agentReconciliationService.verifyDeposit(id, testUser.id)
+            );
+
+            await Promise.all(promises);
+
+            // 4. Check final balance: 2000 - (5 * 100) = 1500
+            const finalBalance = await agentReconciliationService.getAgentBalance(testAgent.id);
+            expect(Number(finalBalance!.currentBalance)).toBe(1500);
+            expect(Number(finalBalance!.totalDeposited)).toBe(500);
         });
-
-        // 2. Create 5 deposits of 100 each
-        const depositIds: number[] = [];
-        for (let i = 0; i < 5; i++) {
-            const d = await agentReconciliationService.createDeposit(testAgent.id, 100, 'bank_transfer', `REF-CON-${i}`);
-            depositIds.push(d.id);
-        }
-
-        // 3. Verify all deposits concurrently
-        // Note: In a real scenario, different admins might verify them at the same time.
-        const promises = depositIds.map(id =>
-            agentReconciliationService.verifyDeposit(id, testUser.id)
-        );
-
-        await Promise.all(promises);
-
-        // 4. Check final balance: 2000 - (5 * 100) = 1500
-        const finalBalance = await agentReconciliationService.getAgentBalance(testAgent.id);
-        expect(Number(finalBalance!.currentBalance)).toBe(1500);
-        expect(Number(finalBalance!.totalDeposited)).toBe(500);
     }, 60000);
 });

--- a/backend/src/__tests__/integration/agentCollectionWorkflow.test.ts
+++ b/backend/src/__tests__/integration/agentCollectionWorkflow.test.ts
@@ -6,6 +6,7 @@ import { GL_ACCOUNTS } from '../../config/glAccounts';
 import { Decimal } from '@prisma/client/runtime/library';
 import { AccountType, NormalBalance, Prisma } from '@prisma/client';
 import { GLAccountService } from '../../services/glAccountService';
+import { withGlTestTenant } from './helpers/glTestTenant';
 
 // Mock socket instance
 jest.mock('../../utils/socketInstance', () => ({
@@ -30,20 +31,23 @@ describe('Agent Collection Workflow Integration', () => {
 
     beforeEach(async () => {
         GLAccountService.clearCache();
-        // Clean up - Order matters due to foreign keys
-        await prisma.accountTransaction.deleteMany({});
-        await (prisma as any).agentDeposit.deleteMany({});
-        await (prisma as any).agentCollection.deleteMany({});
-        await (prisma as any).agentBalance.deleteMany({});
-        await prisma.delivery.deleteMany({});
-        await prisma.orderItem.deleteMany({});
-        await prisma.order.deleteMany({});
-        await prisma.journalEntry.deleteMany({});
-        await prisma.transaction.deleteMany({});
-        await prisma.customer.deleteMany({});
-        await prisma.account.deleteMany({});
-        await prisma.user.deleteMany({
-            where: { email: { in: ['admin@test.com', 'agent@test.com'] } }
+        // Unscoped cleanup, then seed + enter tenant context (mirrors a request).
+        await withGlTestTenant(async () => {
+            // Clean up - Order matters due to foreign keys
+            await prisma.accountTransaction.deleteMany({});
+            await (prisma as any).agentDeposit.deleteMany({});
+            await (prisma as any).agentCollection.deleteMany({});
+            await (prisma as any).agentBalance.deleteMany({});
+            await prisma.delivery.deleteMany({});
+            await prisma.orderItem.deleteMany({});
+            await prisma.order.deleteMany({});
+            await prisma.journalEntry.deleteMany({});
+            await prisma.transaction.deleteMany({});
+            await prisma.customer.deleteMany({});
+            await prisma.account.deleteMany({});
+            await prisma.user.deleteMany({
+                where: { email: { in: ['admin@test.com', 'agent@test.com'] } }
+            });
         });
 
         // Setup GL Accounts

--- a/backend/src/__tests__/integration/bulkAgentCollection.test.ts
+++ b/backend/src/__tests__/integration/bulkAgentCollection.test.ts
@@ -5,6 +5,7 @@ import { GL_ACCOUNTS } from '../../config/glAccounts';
 import { Decimal } from '@prisma/client/runtime/library';
 import { AccountType, NormalBalance, Prisma } from '@prisma/client';
 import { GLAccountService } from '../../services/glAccountService';
+import { withGlTestTenant } from './helpers/glTestTenant';
 
 // Mock socket instance
 jest.mock('../../utils/socketInstance', () => ({
@@ -22,8 +23,26 @@ describe('Bulk Agent Collection Reconciliation Integration', () => {
     let testOrders: any[] = [];
     let draftCollections: any[] = [];
 
-    beforeAll(async () => {
-        // Ensure necessary GL accounts exist
+    beforeEach(async () => {
+        GLAccountService.clearCache();
+        // Unscoped cleanup, then seed + enter tenant context (mirrors a request).
+        await withGlTestTenant(async () => {
+            // Clean up - Order matters due to foreign keys
+            await prisma.accountTransaction.deleteMany({});
+            await (prisma as any).agentCollection.deleteMany({});
+            await (prisma as any).agentBalance.deleteMany({});
+            await prisma.delivery.deleteMany({});
+            await prisma.orderItem.deleteMany({});
+            await prisma.order.deleteMany({});
+            await prisma.journalEntry.deleteMany({});
+            await prisma.customer.deleteMany({});
+            await prisma.account.deleteMany({});
+            await prisma.user.deleteMany({
+                where: { email: { in: ['admin-bulk@test.com', 'agent-bulk@test.com'] } }
+            });
+        });
+
+        // Ensure necessary GL accounts exist (under tenant context so they're scoped)
         const accounts: Prisma.AccountUncheckedCreateInput[] = [
             { code: '1015', name: 'Cash in Transit', accountType: AccountType.asset, normalBalance: NormalBalance.debit },
             { code: '1020', name: 'Agent AR', accountType: AccountType.asset, normalBalance: NormalBalance.debit },
@@ -36,22 +55,6 @@ describe('Bulk Agent Collection Reconciliation Integration', () => {
                 create: a
             });
         }
-    });
-
-    beforeEach(async () => {
-        GLAccountService.clearCache();
-        // Clean up - Order matters due to foreign keys
-        await prisma.accountTransaction.deleteMany({});
-        await (prisma as any).agentCollection.deleteMany({});
-        await (prisma as any).agentBalance.deleteMany({});
-        await prisma.delivery.deleteMany({});
-        await prisma.orderItem.deleteMany({});
-        await prisma.order.deleteMany({});
-        await prisma.journalEntry.deleteMany({});
-        await prisma.customer.deleteMany({});
-        await prisma.user.deleteMany({
-            where: { email: { in: ['admin-bulk@test.com', 'agent-bulk@test.com'] } }
-        });
 
         // Create Users
         testUser = await prisma.user.create({

--- a/backend/src/__tests__/integration/deliveryGLIntegration.test.ts
+++ b/backend/src/__tests__/integration/deliveryGLIntegration.test.ts
@@ -10,6 +10,7 @@ import { DeliveryService } from '../../services/deliveryService';
 import { OrderService } from '../../services/orderService';
 import { Decimal } from '@prisma/client/runtime/library';
 import { GL_ACCOUNTS } from '../../config/glAccounts';
+import { withGlTestTenant } from './helpers/glTestTenant';
 
 // Mock socket instance
 jest.mock('../../utils/socketInstance', () => ({
@@ -46,26 +47,28 @@ describe('Delivery GL Integration', () => {
   });
 
   beforeEach(async () => {
-    // Clean up test data in correct order to avoid FK issues
-    await prisma.accountTransaction.deleteMany({});
-    await (prisma as any).agentCollection.deleteMany({});
-    await prisma.delivery.deleteMany({});
-    await prisma.orderItem.deleteMany({});
-    await (prisma as any).formSubmission.deleteMany({});
-    await prisma.order.deleteMany({});
-    await prisma.journalEntry.deleteMany({});
-    await prisma.transaction.deleteMany({});
-    await (prisma as any).formUpsell.deleteMany({});
-    await (prisma as any).formPackage.deleteMany({});
-    await (prisma as any).checkoutForm.deleteMany({});
-    await (prisma as any).webhookLog.deleteMany({});
-    await (prisma as any).webhookConfig.deleteMany({});
-    await (prisma as any).product_cost_entries.deleteMany({});
-    await prisma.product.deleteMany({});
-    await prisma.customer.deleteMany({});
-    await prisma.account.deleteMany({});
-    await prisma.user.deleteMany({
-      where: { email: { in: ['testuser@example.com', 'testagent@example.com'] } },
+    // Unscoped cleanup, then seed + enter tenant context (mirrors a request).
+    await withGlTestTenant(async () => {
+      await prisma.accountTransaction.deleteMany({});
+      await (prisma as any).agentCollection.deleteMany({});
+      await prisma.delivery.deleteMany({});
+      await prisma.orderItem.deleteMany({});
+      await (prisma as any).formSubmission.deleteMany({});
+      await prisma.order.deleteMany({});
+      await prisma.journalEntry.deleteMany({});
+      await prisma.transaction.deleteMany({});
+      await (prisma as any).formUpsell.deleteMany({});
+      await (prisma as any).formPackage.deleteMany({});
+      await (prisma as any).checkoutForm.deleteMany({});
+      await (prisma as any).webhookLog.deleteMany({});
+      await (prisma as any).webhookConfig.deleteMany({});
+      await (prisma as any).product_cost_entries.deleteMany({});
+      await prisma.product.deleteMany({});
+      await prisma.customer.deleteMany({});
+      await prisma.account.deleteMany({});
+      await prisma.user.deleteMany({
+        where: { email: { in: ['testuser@example.com', 'testagent@example.com'] } },
+      });
     });
 
     // Create GL Accounts required for automation

--- a/backend/src/__tests__/integration/glConcurrency.test.ts
+++ b/backend/src/__tests__/integration/glConcurrency.test.ts
@@ -2,26 +2,36 @@ import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
 import prisma from '../../utils/prisma';
 import glService from '../../services/glService';
 import { AccountType, NormalBalance, JournalSourceType } from '@prisma/client';
+import { withGlTestTenant } from './helpers/glTestTenant';
+import { tenantStorage } from '../../utils/tenantContext';
 
 describe('GL Concurrency Integration Test', () => {
     let testAccount: any;
     let offsetAccount: any;
     let systemUser: any;
+    let testTenantId: string;
 
     beforeAll(async () => {
-        // Setup: Create a test account and user
-        systemUser = await prisma.user.findFirst({ where: { role: 'admin' } });
-        if (!systemUser) {
-            systemUser = await prisma.user.create({
-                data: {
-                    email: 'gl-tester@example.com',
-                    password: 'hashed-password',
-                    firstName: 'GL',
-                    lastName: 'Tester',
-                    role: 'admin'
-                }
-            });
-        }
+        // Unscoped cleanup, then seed + enter tenant context (mirrors a request).
+        testTenantId = await withGlTestTenant(async () => {
+            await prisma.accountTransaction.deleteMany({});
+            await prisma.journalEntry.deleteMany({});
+        });
+
+        // Seed under tenant context so account/user rows are tenant-scoped.
+        // Upsert (not create) so the suite is idempotent across local re-runs —
+        // User deletes are soft (isActive:false), so the email would otherwise collide.
+        systemUser = await prisma.user.upsert({
+            where: { email: 'gl-concurrency-tester@example.com' },
+            update: { isActive: true, role: 'admin' },
+            create: {
+                email: 'gl-concurrency-tester@example.com',
+                password: 'hashed-password',
+                firstName: 'GL',
+                lastName: 'Tester',
+                role: 'admin'
+            }
+        });
 
         testAccount = await prisma.account.create({
             data: {
@@ -88,44 +98,48 @@ describe('GL Concurrency Integration Test', () => {
     });
 
     it('should maintain correct balance under heavy concurrent updates', async () => {
-        const concurrentCount = 10;
-        const amount = 100; // Each transaction is 100 debit
-        const expectedBalance = concurrentCount * amount;
+        // restoreMocks wipes the beforeAll getTenantId spy before this test, so run
+        // the body inside real ALS tenant context (faithful to a live request).
+        await tenantStorage.run({ tenantId: testTenantId }, async () => {
+            const concurrentCount = 10;
+            const amount = 100; // Each transaction is 100 debit
+            const expectedBalance = concurrentCount * amount;
 
-        console.log(`Starting ${concurrentCount} concurrent journal entries against Account ${testAccount.code}...`);
+            console.log(`Starting ${concurrentCount} concurrent journal entries against Account ${testAccount.code}...`);
 
-        // Fire all transactions simultaneously
-        const promises = Array.from({ length: concurrentCount }).map((_, i) => {
-            return glService.createJournalEntry({
-                entryDate: new Date(),
-                description: `Concurrent Test Entry ${i}`,
-                sourceType: JournalSourceType.manual,
-                transactions: [
-                    {
-                        accountId: testAccount.id,
-                        debitAmount: amount,
-                        creditAmount: 0,
-                        description: `Debit part ${i}`
-                    },
-                    {
-                        accountId: offsetAccount.id,
-                        debitAmount: 0,
-                        creditAmount: amount,
-                        description: `Credit part ${i}`
-                    }
-                ]
-            }, systemUser);
+            // Fire all transactions simultaneously
+            const promises = Array.from({ length: concurrentCount }).map((_, i) => {
+                return glService.createJournalEntry({
+                    entryDate: new Date(),
+                    description: `Concurrent Test Entry ${i}`,
+                    sourceType: JournalSourceType.manual,
+                    transactions: [
+                        {
+                            accountId: testAccount.id,
+                            debitAmount: amount,
+                            creditAmount: 0,
+                            description: `Debit part ${i}`
+                        },
+                        {
+                            accountId: offsetAccount.id,
+                            debitAmount: 0,
+                            creditAmount: amount,
+                            description: `Credit part ${i}`
+                        }
+                    ]
+                }, systemUser);
+            });
+
+            // Wait for all to complete
+            await Promise.all(promises);
+
+            // Verify final balance
+            const updatedAccount = await prisma.account.findUnique({
+                where: { id: testAccount.id }
+            });
+
+            console.log(`Final balance: ${updatedAccount?.currentBalance.toString()}`);
+            expect(Number(updatedAccount?.currentBalance)).toBe(expectedBalance);
         });
-
-        // Wait for all to complete
-        await Promise.all(promises);
-
-        // Verify final balance
-        const updatedAccount = await prisma.account.findUnique({
-            where: { id: testAccount.id }
-        });
-
-        console.log(`Final balance: ${updatedAccount?.currentBalance.toString()}`);
-        expect(Number(updatedAccount?.currentBalance)).toBe(expectedBalance);
     });
 });

--- a/backend/src/__tests__/integration/helpers/glTestTenant.ts
+++ b/backend/src/__tests__/integration/helpers/glTestTenant.ts
@@ -1,0 +1,27 @@
+import { jest } from '@jest/globals';
+import prisma from '../../../utils/prisma';
+import * as tenantContext from '../../../utils/tenantContext';
+
+/**
+ * GL writes now require a resolvable tenant (account_transactions.tenant_id is
+ * NOT NULL and the GL service throws rather than orphan rows). Integration
+ * fixtures predate multi-tenancy, so they must establish tenant context exactly
+ * like a real authenticated request does.
+ *
+ * This runs the suite's cleanup with NO context (so deleteMany is unscoped and
+ * wipes legacy NULL-tenant rows from older runs), then seeds a stable tenant and
+ * puts it in context so the Prisma extension auto-tags every subsequent fixture
+ * and GL row. Returns the tenant id.
+ */
+export async function withGlTestTenant(cleanup: () => Promise<void>): Promise<string> {
+  jest.spyOn(tenantContext, 'getTenantId').mockReturnValue(null);
+  await cleanup();
+
+  const tenant = await prisma.tenant.upsert({
+    where: { slug: 'gl-integration-test' },
+    update: {},
+    create: { name: 'GL Integration Test', slug: 'gl-integration-test' },
+  });
+  jest.spyOn(tenantContext, 'getTenantId').mockReturnValue(tenant.id);
+  return tenant.id;
+}

--- a/backend/src/__tests__/performance/glPerformance.test.ts
+++ b/backend/src/__tests__/performance/glPerformance.test.ts
@@ -2,14 +2,23 @@ import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
 import prisma from '../../utils/prisma';
 import glService from '../../services/glService';
 import { AccountType, NormalBalance, JournalSourceType } from '@prisma/client';
+import { withGlTestTenant } from '../integration/helpers/glTestTenant';
+import { tenantStorage } from '../../utils/tenantContext';
 
 describe('GL Performance Test', () => {
     let perfAccount: any;
     let offsetAccount: any;
     let systemUser: any;
+    let testTenantId: string;
     const TRANSACTION_COUNT = 200; // Reduced for faster/stable CI
 
     beforeAll(async () => {
+        // Unscoped cleanup, then seed + enter tenant context (mirrors a request).
+        testTenantId = await withGlTestTenant(async () => {
+            await prisma.accountTransaction.deleteMany({});
+            await prisma.journalEntry.deleteMany({ where: { description: { startsWith: 'Seed Entry' } } });
+        });
+
         // Always create a dedicated user for this test to avoid FK issues
         // from concurrent test cleanup deleting shared users
         systemUser = await prisma.user.upsert({
@@ -99,27 +108,32 @@ describe('GL Performance Test', () => {
     });
 
     it('should fetch paginated ledger data efficiently', async () => {
-        const start = Date.now();
-        const result = await glService.getAccountLedger(perfAccount.id.toString(), {
-            page: 1,
-            limit: 50
-        });
-        const duration = Date.now() - start;
+        // restoreMocks wipes the beforeAll getTenantId spy; run reads in real ALS context.
+        await tenantStorage.run({ tenantId: testTenantId }, async () => {
+            const start = Date.now();
+            const result = await glService.getAccountLedger(perfAccount.id.toString(), {
+                page: 1,
+                limit: 50
+            });
+            const duration = Date.now() - start;
 
-        console.log(`Paginated fetch (50/1000) took ${duration}ms`);
-        expect(result.transactions.length).toBe(50);
-        expect(result.pagination.total).toBe(TRANSACTION_COUNT);
-        expect(duration).toBeLessThan(300); // Expect < 300ms (Adjusted for CI)
+            console.log(`Paginated fetch (50/1000) took ${duration}ms`);
+            expect(result.transactions.length).toBe(50);
+            expect(result.pagination.total).toBe(TRANSACTION_COUNT);
+            expect(duration).toBeLessThan(300); // Expect < 300ms (Adjusted for CI)
+        });
     });
 
     it('should export large ledger to CSV efficiently', async () => {
-        const start = Date.now();
-        const result = await glService.exportAccountLedgerToCSV(perfAccount.id.toString(), {});
-        const duration = Date.now() - start;
+        await tenantStorage.run({ tenantId: testTenantId }, async () => {
+            const start = Date.now();
+            const result = await glService.exportAccountLedgerToCSV(perfAccount.id.toString(), {});
+            const duration = Date.now() - start;
 
-        console.log(`CSV Export (${TRANSACTION_COUNT} records) took ${duration}ms`);
-        expect(result.csv).toBeDefined();
-        expect(result.csv.length).toBeGreaterThan(1000);
-        expect(duration).toBeLessThan(1000); // Expect < 1s
+            console.log(`CSV Export (${TRANSACTION_COUNT} records) took ${duration}ms`);
+            expect(result.csv).toBeDefined();
+            expect(result.csv.length).toBeGreaterThan(1000);
+            expect(duration).toBeLessThan(1000); // Expect < 1s
+        });
     });
 });

--- a/backend/src/__tests__/unit/deliveryService.test.ts
+++ b/backend/src/__tests__/unit/deliveryService.test.ts
@@ -5,6 +5,7 @@ import { AppError } from '../../middleware/errorHandler';
 import { OrderStatus, DeliveryProofType } from '@prisma/client';
 import { Decimal } from '@prisma/client/runtime/library';
 import { GLAccountService } from '../../services/glAccountService';
+import * as tenantContext from '../../utils/tenantContext';
 
 // Mock logger
 jest.mock('../../utils/logger', () => ({
@@ -31,6 +32,9 @@ describe('DeliveryService', () => {
     jest.clearAllMocks();
     deliveryService = new DeliveryService();
     (GLAccountService.getAccountIdByCode as jest.Mock).mockResolvedValue(10);
+    // GL writes require a resolvable tenant; in production these run inside an
+    // authenticated request. Mirror that ambient context here.
+    jest.spyOn(tenantContext, 'getTenantId').mockReturnValue('tenant-a');
   });
 
   describe('createDelivery', () => {

--- a/backend/src/__tests__/unit/financialReconciliationQueue.test.ts
+++ b/backend/src/__tests__/unit/financialReconciliationQueue.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { getTenantId } from '../../utils/tenantContext';
 
 // Mock server module
 jest.mock('../../server', () => ({
@@ -112,6 +113,23 @@ describe('financialReconciliationQueue', () => {
       expect.stringContaining('Reconciliation failed for order 2'),
       'GL account not found'
     );
+  });
+
+  it('establishes the order tenant context before syncing (NULL-orphan guard)', async () => {
+    // The cron has no HTTP request, so it must inject the tenant itself —
+    // otherwise the GL rows it writes are tagged tenant_id = NULL.
+    const order = { ...makeOrder(1), tenantId: 'tenant-x' };
+    (prismaMock.order.findMany as any).mockResolvedValue([order]);
+
+    let seenTenant: string | null = 'NOT_CAPTURED' as any;
+    mockSyncOrderFinancialData.mockImplementation(async () => {
+      seenTenant = getTenantId();
+      return { transaction: { id: 1 }, journalEntry: { entryNumber: 'JE-001' } };
+    });
+
+    await processCallback();
+
+    expect(seenTenant).toBe('tenant-x');
   });
 
   it('throws when all orders fail for Bull retry', async () => {

--- a/backend/src/__tests__/unit/glAutomationService.test.ts
+++ b/backend/src/__tests__/unit/glAutomationService.test.ts
@@ -8,6 +8,7 @@ import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { Decimal } from '@prisma/client/runtime/library';
 import { GLAutomationService } from '../../services/glAutomationService';
 import { GLAccountService } from '../../services/glAccountService';
+import * as tenantContext from '../../utils/tenantContext';
 
 // Mock logger
 jest.mock('../../utils/logger', () => ({
@@ -31,6 +32,9 @@ describe('GLAutomationService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (GLAccountService.getAccountIdByCode as jest.Mock).mockResolvedValue(10);
+    // Default: ambient tenant context present (mirrors a request-scoped caller).
+    // Individual tests override this to simulate context-less background callers.
+    jest.spyOn(tenantContext, 'getTenantId').mockReturnValue('tenant-a');
   });
 
   describe('calculateTotalCOGS', () => {
@@ -183,6 +187,86 @@ describe('GLAutomationService', () => {
       );
 
       expect(mockTx.journalEntry.create).toHaveBeenCalled();
+    });
+  });
+
+  // Regression coverage for the NULL-tenant orphan bug: background GL writers
+  // (reconciliation cron / setImmediate) run with no AsyncLocalStorage context,
+  // so nested account_transactions were written tenant_id = NULL and vanished
+  // from tenant-scoped financial reporting. The fix derives tenant from the
+  // order explicitly and fails loud when none is resolvable.
+  describe('tenant stamping on account_transactions (NULL-orphan regression)', () => {
+    const createMockTx = () => ({
+      journalEntry: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockImplementation((args: any) =>
+          Promise.resolve({ id: 1, entryNumber: 'JE-T', transactions: args.data.transactions?.create || [] })
+        ),
+      },
+      account: {
+        findUnique: jest.fn().mockResolvedValue({ normalBalance: 'debit', currentBalance: new Decimal(0) }),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      $queryRaw: jest.fn().mockResolvedValue([]),
+    });
+
+    const orderWithTenant = (tenantId?: string): any => ({
+      id: 1,
+      orderNumber: 'ORD-T',
+      totalAmount: new Decimal(200),
+      shippingCost: new Decimal(0),
+      status: 'delivered',
+      revenueRecognized: false,
+      tenantId,
+      deliveryAgent: { id: 2, commissionAmount: new Decimal(30) },
+      customerRep: { id: 3, commissionAmount: new Decimal(10) },
+      orderItems: [{ product: { name: 'Widget', cogs: new Decimal(50) }, quantity: 1 }],
+    });
+
+    it('stamps every account_transaction with the order tenant even with NO ambient context (cron path)', async () => {
+      // Simulate the reconciliation cron: AsyncLocalStorage is empty.
+      jest.spyOn(tenantContext, 'getTenantId').mockReturnValue(null);
+      const mockTx: any = createMockTx();
+
+      await GLAutomationService.createRevenueRecognitionEntry(
+        mockTx,
+        orderWithTenant('tenant-from-order'),
+        new Decimal(50),
+        1
+      );
+
+      const createCall = mockTx.journalEntry.create.mock.calls[0][0];
+      // Parent entry tagged.
+      expect(createCall.data.tenantId).toBe('tenant-from-order');
+      // Every child transaction tagged — this is what used to be NULL.
+      const children = createCall.data.transactions.create;
+      expect(children.length).toBeGreaterThan(0);
+      for (const child of children) {
+        expect(child.tenantId).toBe('tenant-from-order');
+      }
+    });
+
+    it('throws rather than writing a NULL-tenant entry when no tenant is resolvable', async () => {
+      jest.spyOn(tenantContext, 'getTenantId').mockReturnValue(null);
+      const mockTx: any = createMockTx();
+
+      await expect(
+        GLAutomationService.createRevenueRecognitionEntry(mockTx, orderWithTenant(undefined), new Decimal(50), 1)
+      ).rejects.toThrow(/tenantId/i);
+      expect(mockTx.journalEntry.create).not.toHaveBeenCalled();
+    });
+
+    it('falls back to ambient tenant context for request-scoped callers (no explicit tenant)', async () => {
+      jest.spyOn(tenantContext, 'getTenantId').mockReturnValue('tenant-ambient');
+      const mockTx: any = createMockTx();
+
+      await GLAutomationService.createRevenueRecognitionEntry(mockTx, orderWithTenant(undefined), new Decimal(50), 1);
+
+      const createCall = mockTx.journalEntry.create.mock.calls[0][0];
+      expect(createCall.data.tenantId).toBe('tenant-ambient');
+      for (const child of createCall.data.transactions.create) {
+        expect(child.tenantId).toBe('tenant-ambient');
+      }
     });
   });
 

--- a/backend/src/__tests__/unit/glService.test.ts
+++ b/backend/src/__tests__/unit/glService.test.ts
@@ -14,6 +14,7 @@ import { prismaMock } from '../mocks/prisma.mock';
 import glService from '../../services/glService';
 import { AppError } from '../../middleware/errorHandler';
 import { AccountType, NormalBalance, Prisma } from '@prisma/client';
+import { tenantStorage } from '../../utils/tenantContext';
 
 // Mock logger
 jest.mock('../../utils/logger', () => ({
@@ -758,7 +759,10 @@ describe('GLService', () => {
       (prismaMock.account.update as any).mockResolvedValue({});
       (prismaMock.auditLog.create as any).mockResolvedValue({});
 
-      const result = await glService.createJournalEntry(entryData, mockUser);
+      // createJournalEntry now requires tenant context (stamps children explicitly).
+      const result = await tenantStorage.run({ tenantId: 'test-tenant' }, async () =>
+        glService.createJournalEntry(entryData, mockUser)
+      );
 
       expect(result.id).toBe(10);
       expect(prismaMock.journalEntry.create).toHaveBeenCalled();

--- a/backend/src/queues/financialReconciliationQueue.ts
+++ b/backend/src/queues/financialReconciliationQueue.ts
@@ -3,6 +3,7 @@ import { FinancialSyncService } from '../services/financialSyncService';
 import prisma from '../utils/prisma';
 import logger from '../utils/logger';
 import { SYSTEM_USER_ID } from '../config/constants';
+import { tenantStorage } from '../utils/tenantContext';
 
 const redisConfig = {
     host: process.env.REDIS_HOST || 'localhost',
@@ -61,10 +62,18 @@ financialReconciliationQueue.process('reconcile-delivered-orders', async () => {
 
     for (const order of unsynced) {
         try {
-            const result = await FinancialSyncService.syncOrderFinancialData(
-                prisma as any,
-                order as any,
-                SYSTEM_USER_ID
+            // This cron runs in a Bull worker with no HTTP request, so there is
+            // no AsyncLocalStorage tenant context. Establish it from the order's
+            // own tenant before syncing — otherwise every financial row this job
+            // writes (account_transactions, Transaction, AgentCollection) is
+            // tagged tenant_id = NULL and disappears from tenant-scoped reporting.
+            const result = await tenantStorage.run(
+                { tenantId: (order as any).tenantId ?? null },
+                () => FinancialSyncService.syncOrderFinancialData(
+                    prisma as any,
+                    order as any,
+                    SYSTEM_USER_ID
+                )
             );
 
             if (result.transaction || result.journalEntry) {

--- a/backend/src/services/glAutomationService.ts
+++ b/backend/src/services/glAutomationService.ts
@@ -49,6 +49,12 @@ interface JournalEntryCreateData {
   sourceType: JournalSourceType;
   sourceId: number;
   createdBy: number;
+  // Tenant that owns this entry. Pass explicitly (e.g. order.tenantId) so the
+  // GL write is correct regardless of execution context. Background callers
+  // (reconciliation cron, queues, setImmediate) have no AsyncLocalStorage
+  // tenant context, so relying on getTenantId() alone silently orphans the
+  // nested account_transactions with tenant_id = NULL. See createJournalEntryWithRetry.
+  tenantId?: string;
   transactions: {
     create: TransactionCreateData[];
   };
@@ -148,8 +154,23 @@ export class GLAutomationService {
         // Validate balance before writing
         GLAutomationService.validateJournalEntryBalance(data.transactions.create);
 
+        // Resolve the owning tenant explicitly. Prefer the value the caller
+        // threaded in (e.g. order.tenantId), falling back to ambient context
+        // for request-scoped callers (manual entries). The Prisma tenant
+        // extension only injects tenantId into the TOP-LEVEL create, never the
+        // nested transactions.create — so children must be stamped here.
+        // Fail loud rather than write tenant_id = NULL: a missing tenant means
+        // financial rows that silently disappear from tenant-scoped reporting.
+        const { tenantId: explicitTenantId, ...entryData } = data;
+        const tenantId = explicitTenantId ?? getTenantId();
+        if (!tenantId) {
+          throw new Error(
+            `Cannot create GL journal entry (source ${data.sourceType}#${data.sourceId}) without a tenantId. ` +
+            `Pass tenantId explicitly (e.g. order.tenantId) or run within tenant context.`
+          );
+        }
+
         // First, update account balances and get running balances
-        const tenantId = getTenantId();
         const transactionsWithRunningBalances = [];
         for (const txn of data.transactions.create) {
           const runningBalance = await this.updateAccountBalance(
@@ -162,13 +183,14 @@ export class GLAutomationService {
           transactionsWithRunningBalances.push({
             ...txn,
             runningBalance,
-            ...(tenantId ? { tenantId } : {}),
+            tenantId,
           });
         }
 
         return await tx.journalEntry.create({
           data: {
-            ...data,
+            ...entryData,
+            tenantId,
             entryNumber,
             transactions: {
               create: transactionsWithRunningBalances
@@ -368,6 +390,9 @@ export class GLAutomationService {
       sourceType: JournalSourceType.order_delivery,
       sourceId: order.id,
       createdBy: userId,
+      // Stamp the entry with the order's tenant so the GL write is correct even
+      // when run from the reconciliation cron / setImmediate (no ALS context).
+      tenantId: (order as any).tenantId ?? undefined,
       transactions: {
         create: transactions,
       },
@@ -431,6 +456,7 @@ export class GLAutomationService {
       sourceType: JournalSourceType.failed_delivery,
       sourceId: delivery.id,
       createdBy: userId,
+      tenantId: (order as any).tenantId ?? undefined,
       transactions: {
         create: transactions,
       },
@@ -580,6 +606,7 @@ export class GLAutomationService {
       sourceType: JournalSourceType.order_return,
       sourceId: order.id,
       createdBy: userId,
+      tenantId: (order as any).tenantId ?? undefined,
       transactions: {
         create: transactions,
       },

--- a/backend/src/services/glService.ts
+++ b/backend/src/services/glService.ts
@@ -741,6 +741,19 @@ export class GLService {
     // Validate journal entry data
     await this.validateJournalEntry(data);
 
+    // Resolve the owning tenant explicitly. The Prisma tenant extension only
+    // injects tenantId into the TOP-LEVEL create, never the nested
+    // transactions.create — so the children must be stamped here. Fail loud
+    // rather than write tenant_id = NULL: a missing tenant means financial rows
+    // that silently disappear from tenant-scoped reporting.
+    const tenantId = getTenantId();
+    if (!tenantId) {
+      throw new AppError(
+        'Cannot create journal entry without tenant context. Run within a tenant-scoped request.',
+        400
+      );
+    }
+
     return await prisma.$transaction(async (tx) => {
       // Generate entry number using the transaction client to maintain the lock
       const entryNumber = await this.generateEntryNumber(tx as Prisma.TransactionClient);
@@ -763,13 +776,15 @@ export class GLService {
           debitAmount,
           creditAmount,
           runningBalance,
-          description: txn.description
+          description: txn.description,
+          tenantId
         });
       }
 
       // Create journal entry with transactions
       const entry = await tx.journalEntry.create({
         data: {
+          tenantId,
           entryNumber,
           entryDate: new Date(data.entryDate),
           description: data.description,
@@ -984,6 +999,9 @@ export class GLService {
       const reversingEntryNumber = await this.generateEntryNumber(tx as Prisma.TransactionClient);
       const reversingEntry = await tx.journalEntry.create({
         data: {
+          // Inherit the tenant from the entry being reversed — both parent and
+          // children must be stamped (the extension only covers top-level).
+          tenantId: entry.tenantId,
           entryNumber: reversingEntryNumber,
           entryDate: new Date(),
           description: `VOID: ${entry.description}`,
@@ -995,7 +1013,8 @@ export class GLService {
               accountId: t.accountId,
               debitAmount: t.creditAmount,  // Swapped
               creditAmount: t.debitAmount,   // Swapped
-              description: `Reversal of ${entry.entryNumber}`
+              description: `Reversal of ${entry.entryNumber}`,
+              tenantId: entry.tenantId
             }))
           }
         },


### PR DESCRIPTION
## Problem

The financial module reported **~\$200 of revenue instead of ~₵71k** for June 2026. Tenant-scoped reporting silently hid the real numbers because GL `account_transactions` rows were being written with `tenant_id = NULL`.

This has recurred (first surfaced ~May 25). Root cause confirmed via code, git history, and read-only prod queries (2,596 NULL-tenant rows; 100% had correctly-tagged parent journal entries; all from a single tenant).

## Root cause

`tenantIsolationExtension` injects `tenantId` only into the **top-level** `args.data` on `create`. It does **not** recurse into nested `transactions: { create }`. The GL double-entry posting (`journalEntry.create` with nested transaction children) relied on a fragile manual `getTenantId()` ternary for the children.

When a writer ran **without request context** — the `financialReconciliationQueue` Bull cron (`*/15min`) has no request, so `getTenantId()` returned null — the children were written with `tenant_id = NULL` while the parent was tagged. In-request paths propagated ALS context and tagged correctly, which is why the bug was intermittent.

## Fix (defense in depth)

1. **Structural** — `glAutomationService.createJournalEntryWithRetry` now resolves a single `tenantId` (explicit `order.tenantId` ?? ambient `getTenantId()`) and stamps it on **both** parent and every transaction child. The revenue/failed-delivery/return-reversal entry creators thread `order.tenantId` explicitly.
2. **Guardrail** — the service now **throws** if no tenant can be resolved, rather than silently orphaning rows. A context-less writer fails loudly instead of corrupting reporting.
3. **Context** — `financialReconciliationQueue` wraps each per-order sync in `tenantStorage.run({ tenantId: order.tenantId })` so the cron path always has context.
4. **Schema** — `account_transactions.tenant_id` is now `NOT NULL` (migration backfills existing NULL rows from their parent journal entry first, then sets the constraint), so the DB itself prevents recurrence.

## Tests

- 925 unit tests pass, including a new NULL-orphan regression block.
- All 5 GL/agent integration suites updated to establish tenant context via a new `withGlTestTenant` helper (mirrors an authenticated request).
- **Full backend suite: 1052 passed, 12 skipped, 0 failures.**

## Deploy note ⚠️

The migration runs a **backfill + `SET NOT NULL` on live financial data**. Recommend applying to **staging first** given the pre-existing migration-drift history. Not yet deployed — awaiting approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)