### PR TITLE
fix(gl): make develop build green — stamp tenantId on remaining AccountTransaction creates

### DIFF
--- a/backend/src/__tests__/unit/glService.test.ts
+++ b/backend/src/__tests__/unit/glService.test.ts
@@ -833,6 +833,7 @@ describe('GLService', () => {
         id: 10,
         entryNumber: 'JE-001',
         description: 'Test',
+        tenantId: 'test-tenant', // reversing entry inherits the source entry's tenant
         transactions: [
           { accountId: 1, debitAmount: new Prisma.Decimal('100'), creditAmount: new Prisma.Decimal('0') },
           { accountId: 2, debitAmount: new Prisma.Decimal('0'), creditAmount: new Prisma.Decimal('100') }

--- a/backend/src/controllers/financialController.ts
+++ b/backend/src/controllers/financialController.ts
@@ -538,6 +538,15 @@ export const backfillCommissions = async (_req: AuthRequest, res: Response): Pro
     const commPayableAccountId = await GLAccountService.getAccountIdByCode(GL_ACCOUNTS.COMMISSIONS_PAYABLE);
     const cashInTransitAccountId = await GLAccountService.getAccountIdByCode(GL_ACCOUNTS.CASH_IN_TRANSIT);
 
+    // account_transactions.tenant_id is NOT NULL — stamp every created row with
+    // the request's tenant rather than relying on the extension (which covers
+    // only the top-level create, and never nested children).
+    const tenantId = getTenantId();
+    if (!tenantId) {
+      res.status(400).json({ message: 'Cannot backfill commissions without tenant context.' });
+      return;
+    }
+
     // Find all order_delivery JEs that have NO commission transactions
     const journalEntries = await prisma.journalEntry.findMany({
       where: {
@@ -602,6 +611,7 @@ export const backfillCommissions = async (_req: AuthRequest, res: Response): Pro
               debitAmount: agentComm,
               creditAmount: new Decimal(0),
               description: `Backfill: Delivery agent commission - Order #${order.id}`,
+              tenantId,
             },
           });
           // Reduce Cash in Transit (agent keeps commission from collection)
@@ -632,6 +642,7 @@ export const backfillCommissions = async (_req: AuthRequest, res: Response): Pro
               debitAmount: repComm,
               creditAmount: new Decimal(0),
               description: `Backfill: Sales rep commission - Order #${order.id}`,
+              tenantId,
             },
           });
           await tx.accountTransaction.create({
@@ -641,6 +652,7 @@ export const backfillCommissions = async (_req: AuthRequest, res: Response): Pro
               debitAmount: new Decimal(0),
               creditAmount: repComm,
               description: `Backfill: Commissions payable - Order #${order.id}`,
+              tenantId,
             },
           });
           await tx.account.update({

--- a/backend/src/services/glService.ts
+++ b/backend/src/services/glService.ts
@@ -995,13 +995,20 @@ export class GLService {
         throw new AppError('Journal entry is already voided', 400);
       }
 
+      // The reversing entry inherits the tenant of the entry being reversed —
+      // both parent and children must be stamped (the extension only covers
+      // the top-level create). account_transactions.tenant_id is NOT NULL, so a
+      // legacy entry with a null tenant cannot be safely reversed.
+      const tenantId = entry.tenantId;
+      if (!tenantId) {
+        throw new AppError('Cannot void a journal entry that has no tenant.', 400);
+      }
+
       // Create reversing entry with swapped debits/credits
       const reversingEntryNumber = await this.generateEntryNumber(tx as Prisma.TransactionClient);
       const reversingEntry = await tx.journalEntry.create({
         data: {
-          // Inherit the tenant from the entry being reversed — both parent and
-          // children must be stamped (the extension only covers top-level).
-          tenantId: entry.tenantId,
+          tenantId,
           entryNumber: reversingEntryNumber,
           entryDate: new Date(),
           description: `VOID: ${entry.description}`,
@@ -1014,7 +1021,7 @@ export class GLService {
               debitAmount: t.creditAmount,  // Swapped
               creditAmount: t.debitAmount,   // Swapped
               description: `Reversal of ${entry.entryNumber}`,
-              tenantId: entry.tenantId
+              tenantId
             }))
           }
         },


### PR DESCRIPTION
## Why
PR #250 merged the GL tenant-orphan fix. On the **develop** push, the Docker
build failed (`npm run build`) with TS2322 errors: a fresh `prisma generate`
against the new schema (`account_transactions.tenant_id` NOT NULL) makes every
nested/direct `AccountTransaction` create require a **non-null** `tenantId`.
The stale local Prisma client had masked these at dev time.

This makes develop's build green again.

## Changes
- **financialController.backfillCommissions** — resolve the request tenant once
  (guard), stamp all three direct `accountTransaction.create` calls.
- **glService.voidJournalEntry** — narrow the (nullable) source `entry.tenantId`
  to a non-null local before stamping the reversing entry's parent + children;
  refuse to void a legacy entry with no tenant.
- **glService unit test** — void mock now carries `tenantId`.

## Verification
- `npx prisma generate` + `npx tsc --noEmit` + `npm run build` — all clean.
- Full integration suite green (8 passed); changed GL suites (unit + concurrency
  + performance) green — 38 passed.
- Pre-push hook (lint + full backend tests + builds + workflow validation) passed.

## Note
This is the same investigation thread as #250 — completing the structural fix
across the GL writers the schema constraint surfaced. No production deploy yet;
the prod backfill migration remains gated on explicit approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)