### PR TITLE
fix(ops): make prod DB backup real (was silently empty)

### DIFF
--- a/scripts/backup-database.sh
+++ b/scripts/backup-database.sh
@@ -4,6 +4,7 @@
 # Usage: ./scripts/backup-database.sh
 
 set -e
+set -o pipefail  # so a pg_dump failure in the dump | gzip pipe aborts the script
 
 # Colors for output
 RED='\033[0;31m'
@@ -29,20 +30,34 @@ echo -e "${GREEN}Starting database backup...${NC}"
 # Create backup directory if it doesn't exist
 mkdir -p "${BACKUP_DIR}"
 
-# Run backup using docker-compose
-docker-compose -f docker-compose.prod.yml exec -T postgres \
-    pg_dump -U "${POSTGRES_USER}" "${POSTGRES_DB}" | gzip > "${BACKUP_FILE}"
-
-if [ $? -eq 0 ]; then
-    echo -e "${GREEN}Backup completed successfully: ${BACKUP_FILE}${NC}"
-    
-    # Get file size
-    SIZE=$(du -h "${BACKUP_FILE}" | cut -f1)
-    echo -e "${GREEN}Backup size: ${SIZE}${NC}"
-else
-    echo -e "${RED}Backup failed!${NC}"
+# Resolve the production postgres container by its pinned container_name.
+# Do NOT use `docker-compose exec postgres` here: on this host it resolves to the
+# wrong container (ecommerce-cod-postgres-staging) or none, producing an empty
+# dump. The prod compose file pins `container_name: ecommerce-cod-postgres`, so
+# match it exactly — an unanchored name filter would also catch the -staging
+# container, so the regex is anchored.
+PG_CONTAINER=$(docker ps --filter "name=^ecommerce-cod-postgres$" --format '{{.ID}}' | head -1)
+if [ -z "${PG_CONTAINER}" ]; then
+    echo -e "${RED}Backup failed: container 'ecommerce-cod-postgres' not found or not running.${NC}"
     exit 1
 fi
+
+# Run backup (pipefail above ensures a pg_dump failure aborts before the verify step)
+docker exec "${PG_CONTAINER}" pg_dump -U "${POSTGRES_USER}" "${POSTGRES_DB}" | gzip > "${BACKUP_FILE}"
+
+# Verify the backup is real — an empty pg_dump still produces a ~20-byte gzip,
+# which previously slipped through as "success". Fail loudly if it is too small.
+MIN_BYTES=1000
+DECOMPRESSED_BYTES=$(gzip -dc "${BACKUP_FILE}" 2>/dev/null | wc -c | tr -d ' ')
+if [ "${DECOMPRESSED_BYTES:-0}" -lt "${MIN_BYTES}" ]; then
+    echo -e "${RED}Backup failed: dump is empty or too small (${DECOMPRESSED_BYTES} bytes uncompressed).${NC}"
+    rm -f "${BACKUP_FILE}"
+    exit 1
+fi
+
+echo -e "${GREEN}Backup completed successfully: ${BACKUP_FILE}${NC}"
+SIZE=$(du -h "${BACKUP_FILE}" | cut -f1)
+echo -e "${GREEN}Backup size: ${SIZE} (${DECOMPRESSED_BYTES} bytes uncompressed)${NC}"
 
 # Remove old backups
 echo -e "${YELLOW}Removing backups older than ${RETENTION_DAYS} days...${NC}"


### PR DESCRIPTION
## Problem

The production deploy's backup step (`scripts/backup-database.sh`, called by `deploy-github-actions.sh`) was silently producing **empty 20-byte gzip files** while printing "Backup completed successfully". Discovered during the GL revenue-fix prod deploy (#252): the reported backup was 4.0K / 0 bytes uncompressed. Every prod deploy's safety net was fake.

## Root cause (two compounding bugs)

1. **Wrong container.** The script dumped via `docker-compose -f docker-compose.prod.yml exec -T postgres`. On the prod host there are two postgres containers — `ecommerce-cod-postgres` (prod data) and `ecommerce-cod-postgres-staging`. `docker compose ... exec postgres` resolves to the staging container or none, not the prod data container → empty/failed output.
2. **Pipe status bug.** `if [ $? -eq 0 ]` checks `gzip`'s exit status (always 0 on empty input), not `pg_dump`'s, and there was no `set -o pipefail`. So empty output was reported as success.

## Fix

- Resolve the prod container by its pinned `container_name` (`ecommerce-cod-postgres`), anchored (`name=^ecommerce-cod-postgres$`) so it doesn't also match `-staging`, and dump via `docker exec`.
- Add `set -o pipefail`.
- Verify the decompressed dump is ≥ 1KB; fail loudly (and delete the bad file) otherwise.

## Verification

Tested on prod (read-only, dump to /tmp): corrected logic resolves `ecommerce-cod-postgres`, pipe exit 0, **4.1MB gzip / 48,486,843 bytes uncompressed, verification PASS**. The old `docker-compose exec` path returns 0 bytes on the same host.

Scope: ops script only. Takes effect on the next prod deploy (workflow does `git reset --hard origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)