### PR TITLE
fix(mcp): return real add-on name in orders_search

### DIFF
--- a/backend/src/mcp/tools/orders.ts
+++ b/backend/src/mcp/tools/orders.ts
@@ -93,7 +93,12 @@ export function registerOrderTools(
             customerPhone: o.customer?.phoneNumber,
             customerAltPhone: o.customer?.alternatePhone ?? null,
             agent: o.deliveryAgent ? `${o.deliveryAgent.firstName} ${o.deliveryAgent.lastName}` : null,
-            items: o.orderItems.map((i) => ({ product: i.product?.name, qty: i.quantity, price: i.unitPrice })),
+            // Upsell rows point productId at the parent product; the real add-on name lives in metadata.upsellName.
+            items: o.orderItems.map((i) => ({
+              product: (i.metadata as any)?.upsellName ?? i.product?.name,
+              qty: i.quantity,
+              price: i.unitPrice,
+            })),
           })),
           total: results.length,
           nextCursor,


### PR DESCRIPTION
## What
`orders_search` now returns the real add-on name for upsell line items by preferring `metadata.upsellName` over the parent product name.

## Why
Upsell OrderItems fall back to the parent product's `productId` (see `publicOrderService.ts`), so `i.product?.name` returned e.g. "Dictamni Hemorrhoid Cream" for the add-on instead of "WinsTown Hemorrhoid Tea". The only prior signal was the differing unit price. This surfaces the correct name to downstream consumers (e.g. the Logiswift delivery manifest import).

## Change
One mapping line in `backend/src/mcp/tools/orders.ts`: `product: (i.metadata as any)?.upsellName ?? i.product?.name`. `metadata` is already loaded (orderItems uses `include`). No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)