### PR TITLE
release: add-on name fix in orders_search MCP

### DIFF
--- a/backend/src/mcp/tools/orders.ts
+++ b/backend/src/mcp/tools/orders.ts
@@ -93,7 +93,12 @@ export function registerOrderTools(
             customerPhone: o.customer?.phoneNumber,
             customerAltPhone: o.customer?.alternatePhone ?? null,
             agent: o.deliveryAgent ? `${o.deliveryAgent.firstName} ${o.deliveryAgent.lastName}` : null,
-            items: o.orderItems.map((i) => ({ product: i.product?.name, qty: i.quantity, price: i.unitPrice })),
+            // Upsell rows point productId at the parent product; the real add-on name lives in metadata.upsellName.
+            items: o.orderItems.map((i) => ({
+              product: (i.metadata as any)?.upsellName ?? i.product?.name,
+              qty: i.quantity,
+              price: i.unitPrice,
+            })),
           })),
           total: results.length,
           nextCursor,


### PR DESCRIPTION
Promotes PR #258 to production. `orders_search` now returns the real add-on name (`metadata.upsellName`) for upsell line items instead of the parent product name. Enables correct add-on labeling in the Logiswift delivery manifest import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)