### PR TITLE
feat(uploads): store product images in Cloudflare R2

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -88,3 +88,12 @@ PLATFORM_EMAIL_FROM_NAME=COD Admin
 # Optional: Monitoring & Logging
 # SENTRY_DSN=https://...@sentry.io/...
 # LOG_LEVEL=info
+
+# Optional: Cloudflare R2 image storage (S3-compatible)
+# When set, uploaded product images are stored in R2 instead of local disk.
+# If absent, uploads fall back to local disk (fine for local dev).
+# R2_ACCOUNT_ID=<cloudflare-account-id>
+# R2_ACCESS_KEY_ID=<r2-api-token-access-key-id>
+# R2_SECRET_ACCESS_KEY=<r2-api-token-secret>
+# R2_BUCKET=codadmin-uploads
+# R2_PUBLIC_URL=https://img.codadminpro.com

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1078.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@prisma/client": "^5.18.0",
         "@sendgrid/mail": "^8.1.6",
@@ -68,6 +69,314 @@
         "jest-mock-extended": "^3.0.5",
         "supertest": "^6.3.4",
         "ts-jest": "^29.1.2"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.11.tgz",
+      "integrity": "sha512-nW5kNBJBwVxkvBqygBYksS8WUFDO8Ad8OSfsVa+f5KFRRTrHL1rnWZNsWBwc5fC9YvZbET/57+X4hym/jKfV+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1078.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1078.0.tgz",
+      "integrity": "sha512-uQMPma3CzTXPKrRfTkhdKLfXocGoEJwBePcI/ca9iWF+re2gbFSDVV9EIcOrK8ke1OV3Jw4ejNmfmgRVlI5b9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.11",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/credential-provider-node": "^3.972.61",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.57",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.26.tgz",
+      "integrity": "sha512-wRj7Pthvjk3anees97pUWlxlTa0DUjeGrEQU5fKDZVdWZV0ekaprbof0df2uaE9g8u67t035v2j+ne2AW2UMkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.15",
+        "@aws-sdk/xml-builder": "^3.972.33",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.29.0",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.52.tgz",
+      "integrity": "sha512-sxuaHZGHqOgKB8OdL3doXa1NJjqmO60FPfyTnYVKGjX9taRsIEGS9pd+2yALmo06hijZ8L94uSK0kfXZsRmVyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.54.tgz",
+      "integrity": "sha512-e6yz52nq3SpR1oPLcvfsDM7H7k2gIYk/NSn/rwsFqzGXEwr3g0mRMlPbLaKCPCGNZJMU/gZg6/64B3eSam+gBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.59.tgz",
+      "integrity": "sha512-9Um/UpruN76AdpiLnvwChVkJJwJ9Vx9ykk/2AeLxxSCM/YYRD8Kkq2towUk9fZQLV7dd9ATlsi87U7hKs0z/iQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/credential-provider-env": "^3.972.52",
+        "@aws-sdk/credential-provider-http": "^3.972.54",
+        "@aws-sdk/credential-provider-login": "^3.972.58",
+        "@aws-sdk/credential-provider-process": "^3.972.52",
+        "@aws-sdk/credential-provider-sso": "^3.972.58",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.58",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.58.tgz",
+      "integrity": "sha512-H3q96qF8/DJsPsXMVtMRqSWOc85K5O4zos32untdw+vE5vw0f3a6qJo1YqbND4BsEIKd4iZmzzVUq9kV4LjbHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.61.tgz",
+      "integrity": "sha512-2U2KHMRCt1dlZoLU3KZR5g5EL4b0h2HHw96SkaUBK7qvEXPZj5rGRO/3ZTeJmh37dIYQuCnA2273rZOQvmsiHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.52",
+        "@aws-sdk/credential-provider-http": "^3.972.54",
+        "@aws-sdk/credential-provider-ini": "^3.972.59",
+        "@aws-sdk/credential-provider-process": "^3.972.52",
+        "@aws-sdk/credential-provider-sso": "^3.972.58",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.58",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.52.tgz",
+      "integrity": "sha512-Aff9Ebs42lz+Ep1wkS+Nlwh5S0eahakpyskPsuKGjiBJ6ExOjNtxbfKJTKovQtQNgJ7oG1BH6esJwGrbs7qgSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.58.tgz",
+      "integrity": "sha512-syloC58mXOacUqM2toPNfwd7X3jT+tWj0F/cN7qdW1FQyI0q41J0tPf6DIZ56BF0x82iS9j3ALP45MoBz79YuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/token-providers": "3.1078.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.58.tgz",
+      "integrity": "sha512-pTBImKzcGK+pcMKjL0fAJbnYzzYd1c0UDc7BSIOGNQhF9Nuk66vWlIXfYTYyzNSs+w8Q/vfbbNDDU8zdrouwLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.57.tgz",
+      "integrity": "sha512-E7tRmmUb64LlsoI6pZZRTov21K74Fr/MVgYBeNFfBkFzpF8e2tuJkKd4YGmcNwz0UjDs8fMoS0v/MGgHASIx+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.26.tgz",
+      "integrity": "sha512-Lwe3F6K7bs+jEubp1LbrvzeMBYb5fMazJ1IxV9TtKWPF8CSh67Fmwyq9fLz3NL/k55Dfpuph5Dimw76JFgr+SA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz",
+      "integrity": "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1078.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1078.0.tgz",
+      "integrity": "sha512-/uyXLBGu3Lw1GbBA2X66hcOMnKtMcqAIF+3/eHfxBQmUeXF2sdqozDPrTfEr/TnSd0D6deZar+eVyhEqqWu29w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.15.tgz",
+      "integrity": "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
+      "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2926,6 +3235,87 @@
         "type-detect": "4.0.8"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.0.tgz",
+      "integrity": "sha512-sEvpvkBVoMxjoek35XyJFn2ZD3EJ1RpiZrT47WaZodxzAIWS44zkdvbqGE/ZlugtjiQp62cffYZ9ldyRkjAGnA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.5.tgz",
+      "integrity": "sha512-LnjUTNG0GgQlKIq7IioeOrPaEmC5xOd1WtAz24TLSiYQnWX2uHr53GrFuQhkrJBktPYCMga/NbUOW7hFbSA2Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.2.tgz",
+      "integrity": "sha512-q96PSDOAGw+X+nuELd7Cjebps0SYr+YlPbviEX9sLVw+VM4M7VV8hn1nL1mGS6urDu33eQ5A7WhlphaDO6kUyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.2.tgz",
+      "integrity": "sha512-s0yAIRj6TVfHgl+QzVyqal1KMGZ9B5512IrxKc6+dOpw8fUmFL3CvuAhjv0J+aNjUPfVZ2IhqPEDvkB5Ncx9oA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.1.tgz",
+      "integrity": "sha512-SqvuP75p/DmgWWI7jv4kf/UW+V4LFmlUn19s604SgAcRuJRB1vDnWwzZMYCLUcmKxko9wDn6iLgGEIpTNgZbIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.1.tgz",
+      "integrity": "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -4456,6 +4846,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
@@ -11781,6 +12177,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -41,6 +41,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1078.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@prisma/client": "^5.18.0",
     "@sendgrid/mail": "^8.1.6",

--- a/backend/src/config/multer.ts
+++ b/backend/src/config/multer.ts
@@ -3,40 +3,15 @@ import path from 'path';
 import fs from 'fs';
 import { AppError } from '../middleware/errorHandler';
 
-// Ensure uploads directory exists
-const uploadDir = path.join(__dirname, '../../uploads');
+// Ensure uploads directory exists (used only when R2 is not configured)
+export const uploadDir = path.join(__dirname, '../../uploads');
 if (!fs.existsSync(uploadDir)) {
   fs.mkdirSync(uploadDir, { recursive: true });
 }
 
-// Sanitize filename - remove spaces and special characters
-const sanitizeFilename = (filename: string): string => {
-  const ext = path.extname(filename);
-  const nameWithoutExt = path.basename(filename, ext);
-
-  const sanitized = nameWithoutExt
-    .toLowerCase()
-    .replace(/\s+/g, '-')           // Replace spaces with hyphens
-    .replace(/[^a-z0-9-_]/g, '')    // Remove special characters
-    .replace(/-+/g, '-')            // Replace multiple hyphens with single hyphen
-    .replace(/^-|-$/g, '');         // Remove leading/trailing hyphens
-
-  return sanitized;
-};
-
-// Configure storage
-const storage = multer.diskStorage({
-  destination: (_req, _file, cb) => {
-    cb(null, uploadDir);
-  },
-  filename: (_req, file, cb) => {
-    // Generate unique filename: sanitizedname-timestamp-random.ext
-    const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1E9)}`;
-    const ext = path.extname(file.originalname);
-    const sanitizedName = sanitizeFilename(file.originalname);
-    cb(null, `${sanitizedName}-${uniqueSuffix}${ext}`);
-  }
-});
+// Images are buffered in memory so the controller can push them to R2
+// (or write them to disk as a fallback). See uploadController.ts.
+const storage = multer.memoryStorage();
 
 // File filter - only allow images
 const fileFilter = (_req: any, file: Express.Multer.File, cb: multer.FileFilterCallback) => {
@@ -54,7 +29,7 @@ export const upload = multer({
   storage,
   fileFilter,
   limits: {
-    fileSize: 5 * 1024 * 1024,  // 5MB max file size
+    fileSize: 15 * 1024 * 1024, // 15MB max file size
     files: 1,                    // Only 1 file per request (prevent DoS)
     fields: 10,                  // Max 10 form fields (prevent field flooding)
     parts: 20,                   // Max 20 parts in multipart (prevent multipart DoS)
@@ -94,7 +69,7 @@ export const handleUploadErrors = (err: any, _req: any, res: any, next: any) => 
   if (err instanceof multer.MulterError) {
     // Multer-specific errors
     if (err.code === 'LIMIT_FILE_SIZE') {
-      return res.status(400).json({ error: 'File too large (max 5MB)' });
+      return res.status(400).json({ error: 'File too large (max 15MB)' });
     }
     if (err.code === 'LIMIT_FILE_COUNT') {
       return res.status(400).json({ error: 'Too many files (max 1)' });

--- a/backend/src/config/r2.ts
+++ b/backend/src/config/r2.ts
@@ -1,0 +1,65 @@
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import path from 'path';
+
+// Cloudflare R2 (S3-compatible) object storage for uploaded images.
+// When the R2_* env vars are absent (e.g. local dev, CI), the upload
+// controller falls back to local disk storage instead.
+
+const accountId = process.env.R2_ACCOUNT_ID;
+const accessKeyId = process.env.R2_ACCESS_KEY_ID;
+const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY;
+const bucket = process.env.R2_BUCKET;
+// Public base URL that serves the bucket (e.g. https://img.codadminpro.com).
+const publicUrl = process.env.R2_PUBLIC_URL;
+
+export const isR2Configured = (): boolean =>
+  Boolean(accountId && accessKeyId && secretAccessKey && bucket && publicUrl);
+
+const client = isR2Configured()
+  ? new S3Client({
+      region: 'auto',
+      endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+      credentials: { accessKeyId: accessKeyId!, secretAccessKey: secretAccessKey! },
+    })
+  : null;
+
+// Sanitize a filename into a safe slug (no spaces or special characters).
+export const sanitizeFilename = (filename: string): string => {
+  const ext = path.extname(filename);
+  const nameWithoutExt = path.basename(filename, ext);
+  return nameWithoutExt
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-_]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+};
+
+// Build a unique, tenant-scoped object key: products/<tenant>/<name>-<suffix>.<ext>
+export const buildImageKey = (originalName: string, tenantId?: string | null): string => {
+  const ext = path.extname(originalName);
+  const suffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+  const name = sanitizeFilename(originalName) || 'image';
+  const prefix = tenantId ? `products/${tenantId}` : 'products/shared';
+  return `${prefix}/${name}-${suffix}${ext}`;
+};
+
+// Upload a buffer to R2 and return its public URL.
+export const uploadToR2 = async (
+  buffer: Buffer,
+  key: string,
+  contentType: string
+): Promise<string> => {
+  if (!client) {
+    throw new Error('R2 is not configured');
+  }
+  await client.send(
+    new PutObjectCommand({
+      Bucket: bucket!,
+      Key: key,
+      Body: buffer,
+      ContentType: contentType,
+    })
+  );
+  return `${publicUrl!.replace(/\/$/, '')}/${key}`;
+};

--- a/backend/src/controllers/uploadController.ts
+++ b/backend/src/controllers/uploadController.ts
@@ -1,6 +1,10 @@
 import { Response } from 'express';
+import fs from 'fs';
+import path from 'path';
 import { AuthRequest } from '../types';
 import { AppError } from '../middleware/errorHandler';
+import { uploadDir } from '../config/multer';
+import { isR2Configured, uploadToR2, buildImageKey } from '../config/r2';
 import logger from '../utils/logger';
 
 export const uploadImage = async (req: AuthRequest, res: Response): Promise<void> => {
@@ -9,13 +13,22 @@ export const uploadImage = async (req: AuthRequest, res: Response): Promise<void
       throw new AppError('No file uploaded', 400);
     }
 
-    // Get the uploaded file info
     const file = req.file;
+    const tenantId = req.user?.tenantId;
+    const key = buildImageKey(file.originalname, tenantId);
 
-    // Return relative URL so it works with frontend proxy
-    const imageUrl = `/uploads/${file.filename}`;
+    let imageUrl: string;
+    if (isR2Configured()) {
+      // Durable object storage — survives redeploys and the disk cleanup cron.
+      imageUrl = await uploadToR2(file.buffer, key, file.mimetype);
+    } else {
+      // Local fallback (dev/CI): write the buffered file to disk.
+      const filename = path.basename(key);
+      await fs.promises.writeFile(path.join(uploadDir, filename), file.buffer);
+      imageUrl = `/uploads/${filename}`;
+    }
 
-    logger.info(`Image uploaded successfully: ${file.filename}`);
+    logger.info(`Image uploaded successfully: ${key}`);
 
     res.status(200).json({
       success: true,
@@ -23,7 +36,7 @@ export const uploadImage = async (req: AuthRequest, res: Response): Promise<void
       imageUrl,
       url: imageUrl, // Include both formats for compatibility
       file: {
-        filename: file.filename,
+        filename: path.basename(key),
         originalName: file.originalname,
         mimetype: file.mimetype,
         size: file.size

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -86,6 +86,11 @@ services:
       META_APP_ID: ${META_APP_ID:-}
       META_APP_SECRET: ${META_APP_SECRET:-}
       BACKEND_URL: ${BACKEND_URL:-https://codadminpro.com}
+      R2_ACCOUNT_ID: ${R2_ACCOUNT_ID:-}
+      R2_ACCESS_KEY_ID: ${R2_ACCESS_KEY_ID:-}
+      R2_SECRET_ACCESS_KEY: ${R2_SECRET_ACCESS_KEY:-}
+      R2_BUCKET: ${R2_BUCKET:-}
+      R2_PUBLIC_URL: ${R2_PUBLIC_URL:-}
     volumes:
       - backend_uploads:/app/uploads
       - backend_logs:/app/logs


### PR DESCRIPTION
## Problem
Product/upsell/delivery-proof image uploads were written to local disk **inside the backend container**. Two silent failure modes:
- **Redeploys** wipe or drift the volume, losing images (product thumbnails 404).
- A **daily cleanup cron** (`server.ts`) deletes any upload older than **60 days**.

Combined with the host nginx **1 MB** body cap (a separate server-side fix), most real product photos never persisted at all.

## Change
Move uploads to **Cloudflare R2** (S3-compatible, durable, zero egress, served via `img.codadminpro.com`).

- add `@aws-sdk/client-s3`; new `backend/src/config/r2.ts` (S3 client, `isR2Configured()`, tenant-scoped key builder, `uploadToR2()`)
- image upload now buffers in memory; controller pushes to R2 when configured, else **falls back to local disk** (keeps dev/CI working without R2 creds)
- keys are **tenant-scoped**: `products/<tenantId>/<name>-<id>.<ext>`
- raise image size limit **5MB → 15MB** (`multer.ts`)
- document `R2_*` env vars in `.env.example` and pass through in `docker-compose.prod.yml`

## Deploy notes (not in this PR)
- Set `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET`, `R2_PUBLIC_URL` on the server `.env` (manual).
- **Host nginx** needs `client_max_body_size 20M;` + reload — uploads >1MB still 413 at the edge until this is done.
- Old disk-stored images are not migrated (mostly already lost); new uploads only.

## Verification
- `tsc --noEmit` passes.
- Fallback path preserves existing behavior when `R2_*` is unset.
- Custom domain `img.codadminpro.com` confirmed wired to the bucket (404 on root path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)