### PR TITLE
fix(checkout): reliable InitiateCheckout + CAPI match quality across all checkout surfaces

### DIFF
--- a/backend/prisma/migrations/20260703053900_add_fb_click_ids/migration.sql
+++ b/backend/prisma/migrations/20260703053900_add_fb_click_ids/migration.sql
@@ -1,0 +1,7 @@
+-- Meta click identifiers (fbp/fbc) captured at checkout, forwarded to the CAPI
+-- Purchase event as match keys. Additive + nullable: safe on existing rows.
+ALTER TABLE "orders" ADD COLUMN "fbp" TEXT;
+ALTER TABLE "orders" ADD COLUMN "fbc" TEXT;
+
+ALTER TABLE "pending_checkouts" ADD COLUMN "fbp" TEXT;
+ALTER TABLE "pending_checkouts" ADD COLUMN "fbc" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -254,6 +254,12 @@ model Order {
   depositPaid        Int                 @default(0) @map("deposit_paid")
   balanceDue         Int                 @default(0) @map("balance_due")
   capiEventFired     Boolean             @default(false) @map("capi_event_fired")
+  // Meta click identifiers captured from the buyer's browser at checkout, forwarded
+  // to the CAPI Purchase event as un-hashed match keys (fbp = browser id cookie,
+  // fbc = click id from the _fbc cookie / fbclid). Nullable: only set for orders
+  // placed through the hosted checkout with a Facebook Pixel configured.
+  fbp                String?             @map("fbp")
+  fbc                String?             @map("fbc")
   deliveryAddress    String?             @map("delivery_address")
   deliveryState      String?             @map("delivery_state")
   deliveryArea       String?             @map("delivery_area")
@@ -797,6 +803,10 @@ model PendingCheckout {
   selectedUpsells     Json?    @map("selected_upsells")
   ipAddress           String?  @map("ip_address")
   userAgent           String?  @map("user_agent")
+  // Meta click identifiers, carried from checkout through to the Order created at
+  // settlement so the Paystack Purchase CAPI event gets the same match keys as COD.
+  fbp                 String?  @map("fbp")
+  fbc                 String?  @map("fbc")
   createdAt           DateTime @default(now()) @map("created_at")
 
   @@index([createdAt])

--- a/backend/src/__tests__/unit/metaCapiService.test.ts
+++ b/backend/src/__tests__/unit/metaCapiService.test.ts
@@ -104,4 +104,89 @@ describe('metaCapiService.fireCapiPurchaseEvent (MAN-59)', () => {
     await expect(metaCapiService.fireCapiPurchaseEvent(42)).resolves.toBeUndefined();
     expect(prismaMock.order.update).not.toHaveBeenCalled();
   });
+
+  it('sends fbp/fbc + client ip/ua un-hashed as match keys when present', async () => {
+    (prismaMock.order.findUnique as any).mockResolvedValue(
+      orderWith(capiForm, {
+        fbp: 'fb.1.123.abc',
+        fbc: 'fb.1.123.CLICKID',
+        formSubmissions: [{ form: capiForm, ipAddress: '10.0.0.9', userAgent: 'Mozilla/5.0 (Linux)' }],
+      }),
+    );
+
+    await metaCapiService.fireCapiPurchaseEvent(42);
+
+    const event = JSON.parse((fetchMock.mock.calls[0] as any)[1].body).data[0];
+    // Raw (not SHA-256'd) — Meta requires fbp/fbc/ip/ua un-hashed.
+    expect(event.user_data.fbp).toBe('fb.1.123.abc');
+    expect(event.user_data.fbc).toBe('fb.1.123.CLICKID');
+    expect(event.user_data.client_ip_address).toBe('10.0.0.9');
+    expect(event.user_data.client_user_agent).toBe('Mozilla/5.0 (Linux)');
+  });
+});
+
+describe('metaCapiService.fireCapiInitiateCheckoutEvent', () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchMock = jest.fn(async () => ({ ok: true, text: async () => '' })) as any;
+    (global as any).fetch = fetchMock;
+    (prismaMock.checkoutForm.findFirst as any).mockResolvedValue(capiForm);
+  });
+
+  const fire = () =>
+    metaCapiService.fireCapiInitiateCheckoutEvent({
+      slug: 'dictamni',
+      eventId: 'evt-123',
+      fbp: 'fb.1.9.p',
+      fbc: 'fb.1.9.c',
+      eventSourceUrl: 'https://shop.example/checkout/dictamni',
+      clientIpAddress: '10.0.0.9',
+      clientUserAgent: 'UA/1',
+    });
+
+  it('POSTs an InitiateCheckout event with the shared eventId and raw match keys', async () => {
+    await fire();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0] as [string, any];
+    expect(url).toContain('/PIXEL123/events');
+    const event = JSON.parse(opts.body).data[0];
+    expect(event.event_name).toBe('InitiateCheckout');
+    expect(event.event_id).toBe('evt-123'); // shared with browser pixel for dedup
+    expect(event.event_source_url).toBe('https://shop.example/checkout/dictamni');
+    expect(event.user_data).toMatchObject({
+      fbp: 'fb.1.9.p',
+      fbc: 'fb.1.9.c',
+      client_ip_address: '10.0.0.9',
+      client_user_agent: 'UA/1',
+    });
+    // No PII / no value at initiate-checkout time.
+    expect(event.user_data.em).toBeUndefined();
+    expect(event.custom_data).toMatchObject({ currency: 'GHS', content_ids: [7], content_type: 'product' });
+    expect(JSON.parse(opts.body).test_event_code).toBe('TEST99');
+  });
+
+  it('no-ops when the form has no CAPI token configured', async () => {
+    (prismaMock.checkoutForm.findFirst as any).mockResolvedValue({ ...capiForm, metaCapiAccessToken: null });
+    await fire();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when the form is not found', async () => {
+    (prismaMock.checkoutForm.findFirst as any).mockResolvedValue(null);
+    await fire();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skips the event when no match keys are available (would be rejected)', async () => {
+    await metaCapiService.fireCapiInitiateCheckoutEvent({ slug: 'dictamni', eventId: 'e' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('never throws — a fetch error is swallowed', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    await expect(fire()).resolves.toBeUndefined();
+  });
 });

--- a/backend/src/controllers/publicOrderController.ts
+++ b/backend/src/controllers/publicOrderController.ts
@@ -16,6 +16,11 @@ import { metaCapiService } from '../services/metaCapiService';
  */
 type PaymentMethod = 'cod' | 'paystack_deposit' | 'paystack_full';
 
+// Meta click ids (fbp/fbc) arrive from the browser; keep only non-empty strings
+// and cap length defensively before they touch the DB or the CAPI payload.
+const clampTracking = (v: unknown): string | null =>
+  typeof v === 'string' && v.trim() ? v.trim().slice(0, 255) : null;
+
 export const getPublicForm = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const { slug } = req.params;
@@ -78,6 +83,11 @@ export const createPublicOrder = async (req: Request, res: Response, next: NextF
       selectedUpsells,
       totalAmount
     } = req.body;
+
+    // Meta click identifiers captured by the checkout page, forwarded to the
+    // Purchase CAPI event (COD fires now; Paystack carries them via PendingCheckout).
+    const fbp = clampTracking(req.body.fbp);
+    const fbc = clampTracking(req.body.fbc);
 
     // Get form with product — the form's tenantId determines the tenant context
     // for this unauthenticated request
@@ -407,6 +417,8 @@ export const createPublicOrder = async (req: Request, res: Response, next: NextF
           selectedUpsells: selectedUpsells ?? Prisma.JsonNull,
           ipAddress: req.ip,
           userAgent: req.get('user-agent'),
+          fbp,
+          fbc,
         },
       });
 
@@ -442,6 +454,8 @@ export const createPublicOrder = async (req: Request, res: Response, next: NextF
         deliveryArea: formData.state || null,
         notes: formData.notes || null,
         source: 'checkout_form',
+        fbp,
+        fbc,
         ...(formTenantId ? { tenantId: formTenantId } : {}),
         orderItems: {
           create: orderItemsData
@@ -505,6 +519,36 @@ export const createPublicOrder = async (req: Request, res: Response, next: NextF
       },
       message: 'Order created successfully'
     });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * Server-side InitiateCheckout: POST /api/public/forms/:slug/track/initiate-checkout
+ *
+ * Fired by the checkout page on load, carrying the shared eventId (so Meta dedupes
+ * against the browser Pixel InitiateCheckout) plus the fbp/fbc cookies. Purely a
+ * tracking side-channel — responds 202 immediately and never blocks the buyer.
+ */
+export const captureInitiateCheckout = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { slug } = req.params;
+    const { eventId, fbp, fbc, eventSourceUrl } = req.body;
+
+    metaCapiService.fireCapiInitiateCheckoutEvent({
+      slug,
+      eventId: clampTracking(eventId),
+      fbp: clampTracking(fbp),
+      fbc: clampTracking(fbc),
+      eventSourceUrl: typeof eventSourceUrl === 'string' ? eventSourceUrl.slice(0, 1000) : null,
+      clientIpAddress: req.ip || null,
+      clientUserAgent: req.get('user-agent') || null,
+    }).catch((err) => {
+      console.error('Meta CAPI InitiateCheckout fire failed:', err);
+    });
+
+    res.status(202).json({ success: true });
   } catch (error) {
     next(error);
   }

--- a/backend/src/routes/publicOrderRoutes.ts
+++ b/backend/src/routes/publicOrderRoutes.ts
@@ -41,11 +41,9 @@ const createOrderValidation = [
 ];
 
 // Only the slug is validated; the tracking fields are best-effort and sanitized
-// in the controller, so a bad value degrades tracking rather than 400-ing.
-const initiateCheckoutValidation = [
-  param('slug').notEmpty().withMessage('Form slug is required')
-    .matches(/^[a-z0-9-]+$/).withMessage('Invalid slug format')
-];
+// in the controller, so a bad value degrades tracking rather than 400-ing. Same
+// shape as getFormValidation — reuse it rather than redeclare an identical rule.
+const initiateCheckoutValidation = getFormValidation;
 
 const trackOrderValidation = [
   body('orderId').notEmpty().withMessage('Order ID is required'),

--- a/backend/src/routes/publicOrderRoutes.ts
+++ b/backend/src/routes/publicOrderRoutes.ts
@@ -35,6 +35,16 @@ const createOrderValidation = [
   body('selectedPackage.quantity').isInt({ min: 1 }).withMessage('Package quantity must be at least 1'),
   body('selectedUpsells').optional().isArray().withMessage('Upsells must be an array'),
   body('totalAmount').isFloat({ min: 0 }).withMessage('Total amount must be positive')
+  // NB: Meta click ids (fbp/fbc) are intentionally NOT validated here — they're
+  // best-effort tracking data sanitized by the controller (clampTracking). A
+  // malformed/oversized value must never block a real order.
+];
+
+// Only the slug is validated; the tracking fields are best-effort and sanitized
+// in the controller, so a bad value degrades tracking rather than 400-ing.
+const initiateCheckoutValidation = [
+  param('slug').notEmpty().withMessage('Form slug is required')
+    .matches(/^[a-z0-9-]+$/).withMessage('Invalid slug format')
 ];
 
 const trackOrderValidation = [
@@ -67,6 +77,14 @@ router.post(
   createOrderValidation,
   validate,
   publicOrderController.createPublicOrder
+);
+
+// Server-side InitiateCheckout signal (fired on checkout-form load)
+router.post(
+  '/forms/:slug/track/initiate-checkout',
+  initiateCheckoutValidation,
+  validate,
+  publicOrderController.captureInitiateCheckout
 );
 
 // Track order by order number and phone (POST to protect PII in request body)

--- a/backend/src/services/metaCapiService.ts
+++ b/backend/src/services/metaCapiService.ts
@@ -23,7 +23,17 @@ const COUNTRY_ISO: Record<string, string> = {
   'south africa': 'za',
 };
 
+const GRAPH_URL = (pixelId: string, accessToken: string): string =>
+  `https://graph.facebook.com/${GRAPH_API_VERSION}/${pixelId}/events?access_token=${encodeURIComponent(accessToken)}`;
+
 const sha256 = (value: string): string => createHash('sha256').update(value).digest('hex');
+
+// Trims empty/whitespace strings to undefined so `compact` drops them — used for
+// the un-hashed match keys (fbp/fbc/ip/ua) that Meta wants raw, not SHA-256'd.
+const raw = (value: string | null | undefined): string | undefined => {
+  const v = value?.trim();
+  return v ? v : undefined;
+};
 
 // SHA-256 of a normalized (trimmed, lowercased) value — Meta's required hashing
 // for PII match keys. Returns undefined for empty input so the key is dropped.
@@ -62,6 +72,8 @@ async function fireCapiPurchaseEvent(orderId: number): Promise<void> {
         totalAmount: true,
         paymentReference: true,
         capiEventFired: true,
+        fbp: true,
+        fbc: true,
         customer: {
           select: { email: true, phoneNumber: true, firstName: true, lastName: true, state: true, area: true },
         },
@@ -69,6 +81,8 @@ async function fireCapiPurchaseEvent(orderId: number): Promise<void> {
           orderBy: { createdAt: 'desc' },
           take: 1,
           select: {
+            ipAddress: true,
+            userAgent: true,
             form: {
               select: {
                 productId: true,
@@ -97,6 +111,7 @@ async function fireCapiPurchaseEvent(orderId: number): Promise<void> {
     if (!pixelId || !accessToken) return;
 
     const customer = order.customer;
+    const submission = order.formSubmissions[0];
     const userData = compact({
       em: hash(customer?.email),
       ph: hashPhone(customer?.phoneNumber),
@@ -104,6 +119,13 @@ async function fireCapiPurchaseEvent(orderId: number): Promise<void> {
       ln: hash(customer?.lastName),
       ct: hash(customer?.area || customer?.state),
       country: hash(COUNTRY_ISO[(form.country || '').trim().toLowerCase()]),
+      // Un-hashed match keys — Meta requires these RAW, never SHA-256'd. fbp/fbc
+      // are the strongest signals when PII (email) is fake/blank, as it often is
+      // for COD. IP/UA come from the checkout submission that created the order.
+      fbp: raw(order.fbp),
+      fbc: raw(order.fbc),
+      client_ip_address: raw(submission?.ipAddress),
+      client_user_agent: raw(submission?.userAgent),
     });
 
     const body = {
@@ -126,8 +148,7 @@ async function fireCapiPurchaseEvent(orderId: number): Promise<void> {
       ...(form.metaCapiTestEventCode ? { test_event_code: form.metaCapiTestEventCode } : {}),
     };
 
-    const url = `https://graph.facebook.com/${GRAPH_API_VERSION}/${pixelId}/events?access_token=${encodeURIComponent(accessToken)}`;
-    const res = await fetch(url, {
+    const res = await fetch(GRAPH_URL(pixelId, accessToken), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -148,5 +169,95 @@ async function fireCapiPurchaseEvent(orderId: number): Promise<void> {
   }
 }
 
-export const metaCapiService = { fireCapiPurchaseEvent };
+/**
+ * Fire a server-side InitiateCheckout event when a buyer loads a checkout form.
+ *
+ * There is no order yet at this point, so this loads pixel/CAPI config straight
+ * from the form (by slug) and carries no PII — it relies on fbp/fbc + IP/UA for
+ * matching. The client Pixel fires the same event with the same `eventId`, so
+ * Meta dedupes browser+server. Best-effort: never throws into the request.
+ *
+ * Unlike Purchase there's no idempotency flag — InitiateCheckout isn't a
+ * conversion and the shared eventId dedupes any repeats within Meta.
+ */
+async function fireCapiInitiateCheckoutEvent(params: {
+  slug: string;
+  eventId?: string | null;
+  fbp?: string | null;
+  fbc?: string | null;
+  eventSourceUrl?: string | null;
+  clientIpAddress?: string | null;
+  clientUserAgent?: string | null;
+}): Promise<void> {
+  try {
+    const form = await prisma.checkoutForm.findFirst({
+      where: { slug: params.slug, isActive: true },
+      select: {
+        productId: true,
+        currency: true,
+        pixelConfig: true,
+        metaCapiAccessToken: true,
+        metaCapiTestEventCode: true,
+      },
+    });
+    if (!form) return;
+
+    const pixelId = (form.pixelConfig as { facebookPixelId?: string } | null)?.facebookPixelId;
+    const accessToken = decryptString(form.metaCapiAccessToken);
+    // CAPI not configured for this form — nothing to do.
+    if (!pixelId || !accessToken) return;
+
+    const userData = compact({
+      fbp: raw(params.fbp),
+      fbc: raw(params.fbc),
+      client_ip_address: raw(params.clientIpAddress),
+      client_user_agent: raw(params.clientUserAgent),
+    });
+    // Meta rejects events with no match keys at all; skip rather than send a
+    // guaranteed-rejected event (should not happen — IP/UA are always present).
+    if (Object.keys(userData).length === 0) return;
+
+    const body = {
+      data: [
+        {
+          event_name: 'InitiateCheckout',
+          event_time: Math.floor(Date.now() / 1000),
+          action_source: 'website',
+          // Same id as the client Pixel InitiateCheckout → Meta dedupes browser+server.
+          ...(raw(params.eventId) ? { event_id: raw(params.eventId) } : {}),
+          ...(raw(params.eventSourceUrl) ? { event_source_url: raw(params.eventSourceUrl) } : {}),
+          user_data: userData,
+          custom_data: {
+            currency: form.currency || 'GHS',
+            content_ids: [form.productId],
+            content_type: 'product',
+          },
+        },
+      ],
+      ...(form.metaCapiTestEventCode ? { test_event_code: form.metaCapiTestEventCode } : {}),
+    };
+
+    const res = await fetch(GRAPH_URL(pixelId, accessToken), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      logger.warn('Meta CAPI InitiateCheckout event rejected', {
+        slug: params.slug,
+        status: res.status,
+        body: text.slice(0, 500),
+      });
+      return;
+    }
+    logger.info('Meta CAPI InitiateCheckout event sent', { slug: params.slug, eventId: raw(params.eventId) });
+  } catch (err: any) {
+    // Best-effort: never propagate into the request flow.
+    logger.error('Meta CAPI InitiateCheckout fire failed (non-fatal)', { slug: params.slug, error: err?.message });
+  }
+}
+
+export const metaCapiService = { fireCapiPurchaseEvent, fireCapiInitiateCheckoutEvent };
 export default metaCapiService;

--- a/backend/src/services/metaCapiService.ts
+++ b/backend/src/services/metaCapiService.ts
@@ -53,6 +53,38 @@ function compact<T extends Record<string, unknown>>(obj: T): Partial<T> {
   return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined)) as Partial<T>;
 }
 
+// Shared send-path for every CAPI event type: wrap the event in Meta's envelope,
+// POST it, and log the outcome. Returns whether Meta accepted it so the caller
+// can run post-send bookkeeping (e.g. marking an order fired). Assumes the outer
+// caller's try/catch handles network errors — keeps each event fn a one-liner.
+async function postCapiEvent(
+  eventLabel: string,
+  pixelId: string,
+  accessToken: string,
+  event: Record<string, unknown>,
+  testEventCode: string | null | undefined,
+  logCtx: Record<string, unknown>,
+): Promise<boolean> {
+  const body = {
+    data: [event],
+    ...(testEventCode ? { test_event_code: testEventCode } : {}),
+  };
+
+  const res = await fetch(GRAPH_URL(pixelId, accessToken), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    logger.warn(`Meta CAPI ${eventLabel} event rejected`, { ...logCtx, status: res.status, body: text.slice(0, 500) });
+    return false;
+  }
+  logger.info(`Meta CAPI ${eventLabel} event sent`, { ...logCtx, eventId: event.event_id });
+  return true;
+}
+
 /**
  * Fire a server-side Purchase event for an order, if its checkout form has Meta
  * CAPI configured. Idempotent via Order.capiEventFired, so it's safe to call
@@ -128,41 +160,26 @@ async function fireCapiPurchaseEvent(orderId: number): Promise<void> {
       client_user_agent: raw(submission?.userAgent),
     });
 
-    const body = {
-      data: [
-        {
-          event_name: 'Purchase',
-          event_time: Math.floor(Date.now() / 1000),
-          action_source: 'website',
-          // Same id as the client Pixel Purchase → Meta dedupes browser+server.
-          event_id: order.paymentReference || String(order.id),
-          user_data: userData,
-          custom_data: {
-            value: order.totalAmount,
-            currency: form.currency || 'GHS',
-            content_ids: [form.productId],
-            content_type: 'product',
-          },
-        },
-      ],
-      ...(form.metaCapiTestEventCode ? { test_event_code: form.metaCapiTestEventCode } : {}),
+    const event = {
+      event_name: 'Purchase',
+      event_time: Math.floor(Date.now() / 1000),
+      action_source: 'website',
+      // Same id as the client Pixel Purchase → Meta dedupes browser+server.
+      event_id: order.paymentReference || String(order.id),
+      user_data: userData,
+      custom_data: {
+        value: order.totalAmount,
+        currency: form.currency || 'GHS',
+        content_ids: [form.productId],
+        content_type: 'product',
+      },
     };
 
-    const res = await fetch(GRAPH_URL(pixelId, accessToken), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
-
-    if (!res.ok) {
-      const text = await res.text().catch(() => '');
-      logger.warn('Meta CAPI Purchase event rejected', { orderId, status: res.status, body: text.slice(0, 500) });
-      return; // leave capiEventFired false so a later settlement site can retry
-    }
+    const ok = await postCapiEvent('Purchase', pixelId, accessToken, event, form.metaCapiTestEventCode, { orderId });
+    if (!ok) return; // leave capiEventFired false so a later settlement site can retry
 
     // Mark fired only after a successful POST so a transient failure can retry.
     await prisma.order.update({ where: { id: orderId }, data: { capiEventFired: true } });
-    logger.info('Meta CAPI Purchase event sent', { orderId, eventId: body.data[0].event_id });
   } catch (err: any) {
     // Best-effort: never propagate into the order flow.
     logger.error('Meta CAPI fire failed (non-fatal)', { orderId, error: err?.message });
@@ -217,42 +234,26 @@ async function fireCapiInitiateCheckoutEvent(params: {
     // guaranteed-rejected event (should not happen — IP/UA are always present).
     if (Object.keys(userData).length === 0) return;
 
-    const body = {
-      data: [
-        {
-          event_name: 'InitiateCheckout',
-          event_time: Math.floor(Date.now() / 1000),
-          action_source: 'website',
-          // Same id as the client Pixel InitiateCheckout → Meta dedupes browser+server.
-          ...(raw(params.eventId) ? { event_id: raw(params.eventId) } : {}),
-          ...(raw(params.eventSourceUrl) ? { event_source_url: raw(params.eventSourceUrl) } : {}),
-          user_data: userData,
-          custom_data: {
-            currency: form.currency || 'GHS',
-            content_ids: [form.productId],
-            content_type: 'product',
-          },
-        },
-      ],
-      ...(form.metaCapiTestEventCode ? { test_event_code: form.metaCapiTestEventCode } : {}),
+    const eventId = raw(params.eventId);
+    const eventSourceUrl = raw(params.eventSourceUrl);
+    const event = {
+      event_name: 'InitiateCheckout',
+      event_time: Math.floor(Date.now() / 1000),
+      action_source: 'website',
+      // Same id as the client Pixel InitiateCheckout → Meta dedupes browser+server.
+      ...(eventId ? { event_id: eventId } : {}),
+      ...(eventSourceUrl ? { event_source_url: eventSourceUrl } : {}),
+      user_data: userData,
+      custom_data: {
+        currency: form.currency || 'GHS',
+        content_ids: [form.productId],
+        content_type: 'product',
+      },
     };
 
-    const res = await fetch(GRAPH_URL(pixelId, accessToken), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
+    await postCapiEvent('InitiateCheckout', pixelId, accessToken, event, form.metaCapiTestEventCode, {
+      slug: params.slug,
     });
-
-    if (!res.ok) {
-      const text = await res.text().catch(() => '');
-      logger.warn('Meta CAPI InitiateCheckout event rejected', {
-        slug: params.slug,
-        status: res.status,
-        body: text.slice(0, 500),
-      });
-      return;
-    }
-    logger.info('Meta CAPI InitiateCheckout event sent', { slug: params.slug, eventId: raw(params.eventId) });
   } catch (err: any) {
     // Best-effort: never propagate into the request flow.
     logger.error('Meta CAPI InitiateCheckout fire failed (non-fatal)', { slug: params.slug, error: err?.message });

--- a/backend/src/services/paystackSettlementService.ts
+++ b/backend/src/services/paystackSettlementService.ts
@@ -137,6 +137,10 @@ export async function settlePaystackPayment(
       notes: formData.notes || null,
       source: 'checkout_form',
       tenantId: pending.tenantId,
+      // Carry the Meta click ids captured at checkout so the Paystack Purchase CAPI
+      // event gets the same match keys as a COD order (see metaCapiService).
+      fbp: pending.fbp,
+      fbc: pending.fbc,
       orderItems: { create: pending.orderItems as Prisma.OrderItemCreateManyOrderInput[] },
     },
     include: { customer: true, orderItems: { include: { product: true } } },

--- a/frontend/embed/EmbedCheckout.tsx
+++ b/frontend/embed/EmbedCheckout.tsx
@@ -3,7 +3,7 @@ import { CheckoutForm, CheckoutFormData } from '../src/components/public/Checkou
 import type { PublicCheckoutForm } from '../src/services/public-orders.service';
 import { fetchFormConfig, buildOrderPayload, submitOrder, trackInitiateCheckout, EmbedFormConfig } from './embedApi';
 import { buildRedirectUrl } from '../src/lib/orderPayload';
-import { trackInitiateCheckout as fireClientInitiateCheckout, getFbCookies } from '../src/utils/pixelTracking';
+import { fireInitiateCheckoutWithCapi, getFbCookies } from '../src/utils/pixelTracking';
 import type { PixelConfig } from '../src/types/checkout-form';
 
 interface EmbedCheckoutProps {
@@ -29,20 +29,13 @@ export const EmbedCheckout: React.FC<EmbedCheckoutProps> = ({ apiBase, slug, loc
 
   // Fire InitiateCheckout once the form config loads. The widget mounts inline in
   // the host page, so the client beacon and _fbp/_fbc cookies belong to the
-  // merchant's domain. Mirrors the hosted checkout: browser beacon + CAPI twin
-  // sharing one eventId so Meta dedupes them. Without this the embed sent no
-  // InitiateCheckout at all (only server-side Purchase reached Meta).
+  // merchant's domain. Uses the same shared helper as the hosted checkout: browser
+  // beacon + CAPI twin sharing one eventId so Meta dedupes them. Without this the
+  // embed sent no InitiateCheckout at all (only server-side Purchase reached Meta).
   useEffect(() => {
     const pixelConfig = form?.pixelConfig as PixelConfig | undefined;
-    if (!pixelConfig?.facebookPixelId) return;
-    const eventId = fireClientInitiateCheckout(pixelConfig);
-    if (eventId) {
-      void trackInitiateCheckout(apiBase, slug, {
-        eventId,
-        eventSourceUrl: window.location.href,
-        ...getFbCookies(),
-      });
-    }
+    if (!pixelConfig) return;
+    fireInitiateCheckoutWithCapi(pixelConfig, (data) => trackInitiateCheckout(apiBase, slug, data));
   }, [form?.pixelConfig, apiBase, slug]);
 
   const handleSubmit = async (data: CheckoutFormData) => {

--- a/frontend/embed/EmbedCheckout.tsx
+++ b/frontend/embed/EmbedCheckout.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { CheckoutForm, CheckoutFormData } from '../src/components/public/CheckoutForm';
 import type { PublicCheckoutForm } from '../src/services/public-orders.service';
-import { fetchFormConfig, buildOrderPayload, submitOrder, EmbedFormConfig } from './embedApi';
+import { fetchFormConfig, buildOrderPayload, submitOrder, trackInitiateCheckout, EmbedFormConfig } from './embedApi';
 import { buildRedirectUrl } from '../src/lib/orderPayload';
+import { trackInitiateCheckout as fireClientInitiateCheckout, getFbCookies } from '../src/utils/pixelTracking';
+import type { PixelConfig } from '../src/types/checkout-form';
 
 interface EmbedCheckoutProps {
   apiBase: string;
@@ -25,11 +27,30 @@ export const EmbedCheckout: React.FC<EmbedCheckoutProps> = ({ apiBase, slug, loc
     };
   }, [apiBase, slug]);
 
+  // Fire InitiateCheckout once the form config loads. The widget mounts inline in
+  // the host page, so the client beacon and _fbp/_fbc cookies belong to the
+  // merchant's domain. Mirrors the hosted checkout: browser beacon + CAPI twin
+  // sharing one eventId so Meta dedupes them. Without this the embed sent no
+  // InitiateCheckout at all (only server-side Purchase reached Meta).
+  useEffect(() => {
+    const pixelConfig = form?.pixelConfig as PixelConfig | undefined;
+    if (!pixelConfig?.facebookPixelId) return;
+    const eventId = fireClientInitiateCheckout(pixelConfig);
+    if (eventId) {
+      void trackInitiateCheckout(apiBase, slug, {
+        eventId,
+        eventSourceUrl: window.location.href,
+        ...getFbCookies(),
+      });
+    }
+  }, [form?.pixelConfig, apiBase, slug]);
+
   const handleSubmit = async (data: CheckoutFormData) => {
     if (!form) return;
     try {
       const { payload, totalAmount } = buildOrderPayload(form, data);
-      const res = await submitOrder(apiBase, slug, payload);
+      // Attach Meta click ids so the Purchase CAPI event can match this buyer.
+      const res = await submitOrder(apiBase, slug, { ...payload, ...getFbCookies() });
 
       // Paystack methods: hand off to Paystack (order created after payment).
       if (res.authorization_url) {

--- a/frontend/embed/embed.tsx
+++ b/frontend/embed/embed.tsx
@@ -26,6 +26,7 @@ import { render } from 'react-dom';
 import { EmbedCheckout } from './EmbedCheckout';
 import { buildOrderPayload, submitOrder, fetchFormConfig } from './embedApi';
 import { buildRedirectUrl } from '../src/lib/orderPayload';
+import { getFbCookies } from '../src/utils/pixelTracking';
 import type { CheckoutFormData } from '../src/components/public/CheckoutForm';
 // Compiled Tailwind CSS, inlined as a string and injected into each Shadow root.
 import embedCss from './embed.css?inline';
@@ -174,7 +175,8 @@ function attachModeB(form: HTMLFormElement): void {
       };
 
       const { payload, totalAmount } = buildOrderPayload(config, data);
-      const res = await submitOrder(API_BASE, slug, payload);
+      // Attach Meta click ids so the Purchase CAPI event can match this buyer.
+      const res = await submitOrder(API_BASE, slug, { ...payload, ...getFbCookies() });
 
       if (res.authorization_url) {
         window.location.href = res.authorization_url;

--- a/frontend/embed/embedApi.ts
+++ b/frontend/embed/embedApi.ts
@@ -32,10 +32,33 @@ export interface OrderResponse {
   order?: { id: number; totalAmount: number; status: string };
 }
 
+// Best-effort server-side InitiateCheckout signal, mirrored from the hosted
+// checkout page. Fired once when the widget loads so the event still reaches
+// Meta via CAPI when the in-app browser blocks the client pixel. The eventId is
+// shared with the browser beacon so Meta dedupes them. Never throws — tracking
+// must not disrupt checkout.
+export async function trackInitiateCheckout(
+  apiBase: string,
+  slug: string,
+  data: { eventId?: string; eventSourceUrl?: string; fbp?: string; fbc?: string },
+): Promise<void> {
+  try {
+    await fetch(`${apiBase}/api/public/forms/${encodeURIComponent(slug)}/track/initiate-checkout`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+      keepalive: true,
+    });
+  } catch {
+    /* best-effort — swallow */
+  }
+}
+
 export async function submitOrder(
   apiBase: string,
   slug: string,
-  payload: ReturnType<typeof buildOrderPayload>['payload'],
+  // fbp/fbc are optional best-effort Meta click ids merged in by the caller.
+  payload: ReturnType<typeof buildOrderPayload>['payload'] & { fbp?: string; fbc?: string },
 ): Promise<OrderResponse> {
   const res = await fetch(`${apiBase}/api/public/forms/${encodeURIComponent(slug)}/orders`, {
     method: 'POST',

--- a/frontend/src/pages/PublicCheckout.tsx
+++ b/frontend/src/pages/PublicCheckout.tsx
@@ -4,7 +4,7 @@ import { CheckoutForm, CheckoutFormData } from '../components/public/CheckoutFor
 import { OrderSuccess } from '../components/public/OrderSuccess';
 import { publicOrdersService, PublicCheckoutForm } from '../services/public-orders.service';
 import { buildOrderPayload, buildRedirectUrl } from '../lib/orderPayload';
-import { initPixels, trackInitiateCheckout } from '../utils/pixelTracking';
+import { initPixels, trackInitiateCheckout, getFbCookies } from '../utils/pixelTracking';
 import { PixelConfig } from '../types/checkout-form';
 import toast from 'react-hot-toast';
 
@@ -97,13 +97,23 @@ export const PublicCheckout: React.FC = () => {
     }
   }, [loading, error, orderId]);
 
-  // Fire pixel PageView events when form data is available
+  // Fire pixel PageView + InitiateCheckout when form data is available.
   useEffect(() => {
-    if (formData?.pixelConfig) {
-      initPixels(formData.pixelConfig as PixelConfig);
-      trackInitiateCheckout(formData.pixelConfig as PixelConfig);
+    if (!formData?.pixelConfig) return;
+    const pixelConfig = formData.pixelConfig as PixelConfig;
+    initPixels(pixelConfig);
+    const eventId = trackInitiateCheckout(pixelConfig);
+
+    // Mirror InitiateCheckout server-side via CAPI so it still lands when the
+    // in-app browser blocks the client pixel. `eventId` is only returned on the
+    // first (non-deduped) fire, so this never double-sends; it shares the eventId
+    // with the browser event so Meta dedupes them.
+    if (slug && eventId && pixelConfig.facebookPixelId) {
+      publicOrdersService
+        .trackInitiateCheckout(slug, { eventId, eventSourceUrl: window.location.href, ...getFbCookies() })
+        .catch(() => { /* tracking is best-effort — never disrupt checkout */ });
     }
-  }, [formData?.pixelConfig]);
+  }, [formData?.pixelConfig, slug]);
 
   const loadForm = async () => {
     try {
@@ -133,7 +143,8 @@ export const PublicCheckout: React.FC = () => {
       // Shared mapping — identical to what the embed widget posts.
       const { payload, totalAmount } = buildOrderPayload(formData, data);
 
-      const response = await publicOrdersService.submitOrder(slug, payload as any);
+      // Attach Meta click ids so the Purchase CAPI event can match this buyer.
+      const response = await publicOrdersService.submitOrder(slug, { ...payload, ...getFbCookies() } as any);
 
       if (response.success) {
         // Paystack methods (digital, deposit, full): redirect to Paystack. The

--- a/frontend/src/pages/PublicCheckout.tsx
+++ b/frontend/src/pages/PublicCheckout.tsx
@@ -4,7 +4,7 @@ import { CheckoutForm, CheckoutFormData } from '../components/public/CheckoutFor
 import { OrderSuccess } from '../components/public/OrderSuccess';
 import { publicOrdersService, PublicCheckoutForm } from '../services/public-orders.service';
 import { buildOrderPayload, buildRedirectUrl } from '../lib/orderPayload';
-import { initPixels, trackInitiateCheckout, getFbCookies } from '../utils/pixelTracking';
+import { initPixels, fireInitiateCheckoutWithCapi, getFbCookies } from '../utils/pixelTracking';
 import { PixelConfig } from '../types/checkout-form';
 import toast from 'react-hot-toast';
 
@@ -97,22 +97,15 @@ export const PublicCheckout: React.FC = () => {
     }
   }, [loading, error, orderId]);
 
-  // Fire pixel PageView + InitiateCheckout when form data is available.
+  // Fire pixel PageView + InitiateCheckout when form data is available. The
+  // InitiateCheckout server-side CAPI mirror is shared with the embed widget.
   useEffect(() => {
-    if (!formData?.pixelConfig) return;
+    if (!formData?.pixelConfig || !slug) return;
     const pixelConfig = formData.pixelConfig as PixelConfig;
     initPixels(pixelConfig);
-    const eventId = trackInitiateCheckout(pixelConfig);
-
-    // Mirror InitiateCheckout server-side via CAPI so it still lands when the
-    // in-app browser blocks the client pixel. `eventId` is only returned on the
-    // first (non-deduped) fire, so this never double-sends; it shares the eventId
-    // with the browser event so Meta dedupes them.
-    if (slug && eventId && pixelConfig.facebookPixelId) {
-      publicOrdersService
-        .trackInitiateCheckout(slug, { eventId, eventSourceUrl: window.location.href, ...getFbCookies() })
-        .catch(() => { /* tracking is best-effort — never disrupt checkout */ });
-    }
+    fireInitiateCheckoutWithCapi(pixelConfig, (data) =>
+      publicOrdersService.trackInitiateCheckout(slug, data),
+    );
   }, [formData?.pixelConfig, slug]);
 
   const loadForm = async () => {

--- a/frontend/src/services/public-orders.service.ts
+++ b/frontend/src/services/public-orders.service.ts
@@ -176,6 +176,14 @@ export const publicOrdersService = {
     return response.data;
   },
 
+  // Server-side InitiateCheckout signal (best-effort; fired on checkout load).
+  async trackInitiateCheckout(
+    slug: string,
+    data: { eventId?: string; eventSourceUrl?: string; fbp?: string; fbc?: string },
+  ): Promise<void> {
+    await publicClient.post(`/api/public/forms/${slug}/track/initiate-checkout`, data);
+  },
+
   async verifyPayment(reference: string): Promise<{ success: boolean; paymentStatus: string; order?: any }> {
     const response = await publicClient.get(`/api/paystack/verify/${reference}`);
     return response.data;

--- a/frontend/src/utils/pixelTracking.ts
+++ b/frontend/src/utils/pixelTracking.ts
@@ -151,9 +151,51 @@ export function initPixels(config: PixelConfig): void {
     loadGTM(config.googleTagManagerId);
 }
 
-export function trackInitiateCheckout(config: PixelConfig): void {
-  if (config.facebookPixelId && window.fbq) {
-    window.fbq('track', 'InitiateCheckout');
+// Reads a browser cookie by exact name, URL-decoded. Returns undefined if absent.
+function readCookie(name: string): string | undefined {
+  const escaped = name.replace(/[.$?*|{}()[\]\\/+^]/g, '\\$&');
+  const match = document.cookie.match(new RegExp('(?:^|; )' + escaped + '=([^;]*)'));
+  return match ? decodeURIComponent(match[1]) : undefined;
+}
+
+// Meta click identifiers for server-side (CAPI) matching. `_fbp` is set by
+// fbevents.js; `_fbc` is derived from the `fbclid` URL param. When fbevents.js is
+// blocked (common in the FB in-app browser) `_fbc` won't exist, so we reconstruct
+// it from `fbclid` in Meta's canonical `fb.1.<ts>.<fbclid>` form.
+export function getFbCookies(): { fbp?: string; fbc?: string } {
+  const fbp = readCookie('_fbp');
+  let fbc = readCookie('_fbc');
+  if (!fbc) {
+    const fbclid = new URLSearchParams(window.location.search).get('fbclid');
+    if (fbclid) fbc = `fb.1.${Date.now()}.${fbclid}`;
+  }
+  const result: { fbp?: string; fbc?: string } = {};
+  if (fbp) result.fbp = fbp;
+  if (fbc) result.fbc = fbc;
+  return result;
+}
+
+// Fires InitiateCheckout across all configured pixels. Returns the Facebook
+// eventID so the caller can pass it to the server-side CAPI event for dedup
+// (undefined when FB isn't configured or the event was already sent this session).
+export function trackInitiateCheckout(config: PixelConfig): string | undefined {
+  let eventId: string | undefined;
+
+  if (config.facebookPixelId && /^\d+$/.test(config.facebookPixelId)) {
+    const beaconKey = `initiatecheckout-${config.facebookPixelId}`;
+    if (!sentBeacons.has(beaconKey)) {
+      sentBeacons.add(beaconKey);
+      eventId = generateEventId();
+      if (window.fbq) {
+        window.fbq('track', 'InitiateCheckout', {}, eventId ? { eventID: eventId } : {});
+      }
+      // Beacon fallback (this is the fix): unlike PageView/Purchase, InitiateCheckout
+      // previously fired through fbq() ONLY. In the Facebook in-app browser
+      // fbevents.js is routinely blocked or the page is killed before fbq's queue
+      // flushes, so the event silently never reached Meta. The image beacon hits
+      // facebook.com/tr directly and always lands; the shared eventID dedupes them.
+      sendFbPixelBeacon(config.facebookPixelId, 'InitiateCheckout', undefined, eventId);
+    }
   }
 
   if (config.googleAnalyticsId && window.gtag) {
@@ -168,6 +210,8 @@ export function trackInitiateCheckout(config: PixelConfig): void {
     window.dataLayer = window.dataLayer || [];
     window.dataLayer.push({ event: 'begin_checkout' });
   }
+
+  return eventId;
 }
 
 export function trackPurchase(config: PixelConfig, value: number, currency: string, orderId?: number | string): void {
@@ -176,7 +220,11 @@ export function trackPurchase(config: PixelConfig, value: number, currency: stri
     const purchaseKey = orderId != null ? `purchase-${config.facebookPixelId}-${orderId}` : null;
     if (!purchaseKey || !sentBeacons.has(purchaseKey)) {
       if (purchaseKey) sentBeacons.add(purchaseKey);
-      const eventId = generateEventId();
+      // Match the server CAPI Purchase event_id, which is order.paymentReference
+      // || String(order.id). This browser Purchase only fires for COD (no payment
+      // reference), so the order id is the shared dedup key — a random UUID here
+      // would make Meta count the browser and CAPI Purchase as two conversions.
+      const eventId = orderId != null ? String(orderId) : generateEventId();
       if (window.fbq) {
         window.fbq('track', 'Purchase', { value, currency }, eventId ? { eventID: eventId } : {});
       }

--- a/frontend/src/utils/pixelTracking.ts
+++ b/frontend/src/utils/pixelTracking.ts
@@ -152,9 +152,10 @@ export function initPixels(config: PixelConfig): void {
 }
 
 // Reads a browser cookie by exact name, URL-decoded. Returns undefined if absent.
+// Only ever called with the literal names `_fbp`/`_fbc`, so `name` needs no
+// regex-escaping.
 function readCookie(name: string): string | undefined {
-  const escaped = name.replace(/[.$?*|{}()[\]\\/+^]/g, '\\$&');
-  const match = document.cookie.match(new RegExp('(?:^|; )' + escaped + '=([^;]*)'));
+  const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
   return match ? decodeURIComponent(match[1]) : undefined;
 }
 
@@ -212,6 +213,23 @@ export function trackInitiateCheckout(config: PixelConfig): string | undefined {
   }
 
   return eventId;
+}
+
+// The InitiateCheckout server-side mirror, shared by every checkout surface
+// (hosted page + embed widget). Fires the client pixel, and when that produced a
+// non-deduped eventId, forwards it to CAPI through the caller-supplied transport
+// with the same eventId so Meta dedupes browser+server. Best-effort — the CAPI
+// call is fire-and-forget and never disrupts checkout. Keeping the eventId guard
+// + eventSourceUrl + fbp/fbc assembly here means the two surfaces can't drift.
+export function fireInitiateCheckoutWithCapi(
+  config: PixelConfig,
+  sendCapi: (data: { eventId: string; eventSourceUrl: string; fbp?: string; fbc?: string }) => Promise<unknown>,
+): void {
+  const eventId = trackInitiateCheckout(config);
+  if (!eventId || !config.facebookPixelId) return;
+  void sendCapi({ eventId, eventSourceUrl: window.location.href, ...getFbCookies() }).catch(() => {
+    /* tracking is best-effort — never disrupt checkout */
+  });
 }
 
 export function trackPurchase(config: PixelConfig, value: number, currency: string, orderId?: number | string): void {


### PR DESCRIPTION
## What & why

Meta was recording **zero InitiateCheckout** events from the checkout in the Facebook in-app browser (Android WebView), and Purchase match quality was weak for COD orders. Root cause: InitiateCheckout fired through `fbq()` only — in the FB in-app browser `fbevents.js` is routinely blocked or the page is killed before the queue flushes, so the event never reached Meta. This branch makes InitiateCheckout reliable, adds a server-side CAPI mirror with shared `event_id` dedup, and forwards Facebook click identifiers (`fbp`/`fbc`) so server events match.

## Changes

**Client (hosted page + embed widget)**
- InitiateCheckout now fires an image beacon (`facebook.com/tr`) alongside `fbq()`, sharing one `eventId` so Meta dedupes them — same pattern PageView/Purchase already used.
- Capture `_fbp`/`_fbc`; reconstruct `_fbc` from the `fbclid` URL param (`fb.1.<ts>.<fbclid>`) when the cookie is absent, and forward on every tracked event.
- Purchase `eventId` uses the order id (COD) so browser + CAPI Purchase dedupe as one conversion.
- Shared `fireInitiateCheckoutWithCapi()` used by both the hosted page and the embed widget so the dedup-critical logic can't drift.

**Server (CAPI)**
- New server-side `InitiateCheckout` CAPI event (loads pixel/CAPI config by slug, matches on `fbp`/`fbc`/IP/UA, shares the client `eventId`).
- `fbp`/`fbc` threaded into all CAPI events as un-hashed match keys.
- Single shared `postCapiEvent()` send-path for Purchase + InitiateCheckout.

**Schema**
- Migration `add_fb_click_ids`: nullable `orders.fbp` / `orders.fbc`.

## Testing
- `metaCapiService` unit tests: 12/12 pass.
- Full backend suite (serial, as CI runs it): **1058 passed, 0 failed**, 12 skipped.
- Backend + frontend + embed builds clean; embed bundle 36 KB gzip.

## Notes
- CAPI is fire-and-forget by contract — a tracking failure never blocks an order.
- After deploy, verify Dictamni (embed Mode A) InitiateCheckout lands in Meta Events Manager once the embed bundle is redeployed to app.codadminpro.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)