### PR TITLE
fix(currency): show tenant's configured currency instead of global USD

### DIFF
--- a/backend/src/__tests__/integration/tenantIsolation.test.ts
+++ b/backend/src/__tests__/integration/tenantIsolation.test.ts
@@ -145,6 +145,13 @@ beforeAll(async () => {
     },
   });
   checkoutFormIdA = formA.id;
+
+  // Per-tenant SystemConfig with distinct currencies — the two tenants must
+  // never see each other's (or the global) currency through the config API.
+  await Promise.all([
+    prismaBase.systemConfig.create({ data: { tenantId: tenantAId, currency: 'GHS' } }),
+    prismaBase.systemConfig.create({ data: { tenantId: tenantBId, currency: 'NGN' } }),
+  ]);
 });
 
 // ── Teardown ───────────────────────────────────────────────────────────────
@@ -345,5 +352,42 @@ describe('Scenario 7 — Prisma middleware behaviour without tenant context', ()
     const ids = allOrders.map((o) => o.tenantId);
     // Both tenants' data is visible when no tenant context is set
     expect(ids).toContain(tenantAId);
+  });
+});
+
+// ── Scenario 8: Per-tenant currency config (Financial "$" bug) ─────────────
+//
+// Regression for the bug where the admin UI rendered "$" even though the tenant
+// had saved GHS: the frontend config store read the UNauthenticated
+// /api/admin/config, which carries no tenant context and therefore returned the
+// global (USD) SystemConfig row. The authenticated /api/admin/config/me route
+// resolves the caller's tenant from the JWT, so each tenant gets its own
+// currency, while the public route must stay tenant-blind.
+
+describe('Scenario 8 — Per-tenant currency config', () => {
+  it('authenticated config route returns Tenant A currency (GHS)', async () => {
+    const res = await request(app)
+      .get('/api/admin/config/me')
+      .set('Authorization', `Bearer ${tokenA}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.currency).toBe('GHS');
+  });
+
+  it('authenticated config route returns Tenant B currency (NGN)', async () => {
+    const res = await request(app)
+      .get('/api/admin/config/me')
+      .set('Authorization', `Bearer ${tokenB}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.currency).toBe('NGN');
+  });
+
+  it('unauthenticated public config stays tenant-blind (no tenant currency leak)', async () => {
+    const res = await request(app).get('/api/admin/config');
+
+    expect(res.status).toBe(200);
+    // Falls back to the global/legacy row — never a specific tenant's currency.
+    expect(res.body.currency).not.toBe('NGN');
   });
 });

--- a/backend/src/routes/adminRoutes.ts
+++ b/backend/src/routes/adminRoutes.ts
@@ -10,6 +10,12 @@ router.get('/config', adminController.getPublicConfig);
 router.use(authenticate);
 router.use(tenantRateLimiter);
 
+// Authenticated tenant config — same public-safe shape as /config, but the JWT
+// gives us tenant context so the caller gets THEIR tenant's currency/business
+// name (the public /config route is tenant-blind and falls back to the global
+// USD row). Available to every authenticated role, not just super_admin.
+router.get('/config/me', adminController.getPublicConfig);
+
 // System Configuration
 router.get('/settings', requireSuperAdmin, adminController.getSystemConfig);
 router.put('/settings', requireSuperAdmin, adminController.updateSystemConfig);

--- a/frontend/src/services/admin.service.ts
+++ b/frontend/src/services/admin.service.ts
@@ -118,6 +118,16 @@ export const adminService = {
     return response.data;
   },
 
+  // Same shape as getPublicConfig, but authenticated so the backend resolves the
+  // caller's tenant from the JWT and returns THEIR currency/business name. The
+  // public /config route is tenant-blind and falls back to the global USD row,
+  // which is why the dashboard showed "$" instead of the tenant's configured
+  // currency. Signed-in surfaces use this; token-less iframe/checkout keeps /config.
+  async getTenantConfig(): Promise<Pick<SystemConfig, 'businessName' | 'currency'>> {
+    const response = await apiClient.get('/api/admin/config/me');
+    return response.data;
+  },
+
   async updateSystemConfig(data: Partial<SystemConfig>): Promise<SystemConfig> {
     const response = await apiClient.put('/api/admin/settings', data);
     return response.data;

--- a/frontend/src/stores/configStore.ts
+++ b/frontend/src/stores/configStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { adminService } from '../services/admin.service';
+import { useAuthStore } from './authStore';
 
 interface ConfigState {
     businessName: string;
@@ -16,14 +17,21 @@ export const useConfigStore = create<ConfigState>((set) => ({
     fetchConfig: async () => {
         set({ isLoading: true });
         try {
-            const config = await adminService.getPublicConfig();
+            // When signed in, fetch the tenant-scoped config so the dashboard shows
+            // THIS tenant's currency. The public /config route is tenant-blind and
+            // falls back to the global USD row (that mismatch was the "$ everywhere"
+            // bug). Token-less surfaces (iframe/checkout bootstrap) use /config.
+            const isAuthenticated = Boolean(useAuthStore.getState().accessToken);
+            const config = isAuthenticated
+                ? await adminService.getTenantConfig()
+                : await adminService.getPublicConfig();
             set({
                 businessName: config.businessName || 'COD Admin',
                 currency: config.currency || 'USD',
                 isLoading: false,
             });
         } catch (error) {
-            console.error('Failed to fetch public config:', error);
+            console.error('Failed to fetch config:', error);
             set({ isLoading: false });
         }
     },

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -8,6 +8,9 @@ export const formatCurrency = (amount: number, currency?: string): string => {
   return new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: targetCurrency,
+    // narrowSymbol renders the local glyph (GH₵5,680.00) instead of the ISO
+    // code prefix (GHS 5,680.00) that 'symbol' falls back to for GHS/NGN.
+    currencyDisplay: 'narrowSymbol',
   }).format(amount);
 };
 


### PR DESCRIPTION
## Problem
Setting **Global Currency = GHS** in Business Settings still rendered all money as `$` across the Financial Management dashboard ($0.00 revenue, $5,680.00 receivables, etc.).

## Root cause
The frontend read currency from the **public** `GET /api/admin/config` route. That route is mounted before `authenticate`, so it's tenant-blind and falls back to the global `SystemConfig` row where `tenantId = null` (currency default `USD`). Settings correctly showed GHS because it uses the authed `/api/admin/settings` route — hence the mismatch.

## Fix
- **backend** — add authenticated `GET /api/admin/config/me` (reuses `getPublicConfig`, but runs with JWT tenant context) so the caller gets *their* tenant's currency/business name. Public `/config` left intact for token-less iframe/checkout bootstrap.
- **frontend** — `configStore.fetchConfig` calls the tenant-scoped route when signed in; falls back to public `/config` when token-less. `App.tsx` already re-runs the fetch on login.
- **format** — render the local glyph via `Intl` `narrowSymbol` (`GH₵` / `₦` / `$`) instead of the ISO-code prefix (`GHS ` / `NGN `) that `'symbol'` falls back to.

## Verification
- Backend `tsc --noEmit`: 0 errors
- New Scenario 8 integration tests (tenant A=GHS, tenant B=NGN isolated; public route stays tenant-blind): **3/3 pass**
- Works for all 3 supported currencies (USD/GHS/NGN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)