### PR TITLE
release: workflow assign_user forward-only fix + prior develop changes

### DIFF
--- a/backend/src/__tests__/unit/workflowAssignUser.test.ts
+++ b/backend/src/__tests__/unit/workflowAssignUser.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { prismaMock } from '../mocks/prisma.mock';
+
+// Sockets are irrelevant to assignment logic; stub them so no real IO module loads.
+jest.mock('../../utils/socketInstance', () => ({
+  getSocketInstance: () => null,
+}));
+jest.mock('../../sockets/index', () => ({
+  emitOrderUpdated: jest.fn(),
+  emitOrderAssigned: jest.fn(),
+}));
+
+import { executeAction } from '../../queues/workflowQueue';
+
+const salesRepAction = (overrides: any = {}) => ({
+  type: 'assign_user',
+  config: {
+    userType: 'sales_rep',
+    distributionMode: 'even',
+    assignments: [{ userId: 2, weight: 100 }],
+    ...overrides,
+  },
+});
+
+describe('executeAssignUserAction (via executeAction)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('forward-only (default: applyToAllUnassigned unset/false)', () => {
+    it('assigns ONLY the triggering order and never sweeps history', async () => {
+      (prismaMock.order.findUnique as any).mockResolvedValue({
+        id: 100,
+        customerRepId: null,
+        orderItems: [],
+      });
+      (prismaMock.order.update as any).mockResolvedValue({ id: 100, customerRepId: 2 });
+
+      const result = await executeAction(salesRepAction(), { id: 100 });
+
+      expect(prismaMock.order.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 100 } })
+      );
+      // The bug was a tenant-wide sweep — findMany must NOT be used in forward-only mode.
+      expect(prismaMock.order.findMany).not.toHaveBeenCalled();
+      expect(prismaMock.order.update).toHaveBeenCalledTimes(1);
+      expect(prismaMock.order.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 100 }, data: { customerRepId: 2 } })
+      );
+      expect(result.assigned).toBe(1);
+    });
+
+    it('never swaps: leaves an order that already has a user untouched', async () => {
+      (prismaMock.order.findUnique as any).mockResolvedValue({
+        id: 100,
+        customerRepId: 9, // already assigned to someone else
+        orderItems: [],
+      });
+
+      const result = await executeAction(salesRepAction(), { id: 100 });
+
+      expect(prismaMock.order.update).not.toHaveBeenCalled();
+      expect(prismaMock.order.findMany).not.toHaveBeenCalled();
+      expect(result.assigned).toBe(0);
+    });
+
+    it('does nothing when there is no triggering order in context', async () => {
+      const result = await executeAction(salesRepAction(), {});
+
+      expect(prismaMock.order.findUnique).not.toHaveBeenCalled();
+      expect(prismaMock.order.findMany).not.toHaveBeenCalled();
+      expect(prismaMock.order.update).not.toHaveBeenCalled();
+      expect(result.assigned).toBe(0);
+    });
+  });
+
+  describe('opt-in backfill (applyToAllUnassigned: true)', () => {
+    it('sweeps every currently-unassigned order for the role', async () => {
+      (prismaMock.order.findMany as any).mockResolvedValue([
+        { id: 1, customerRepId: null, orderItems: [] },
+        { id: 2, customerRepId: null, orderItems: [] },
+      ]);
+      (prismaMock.order.update as any).mockResolvedValue({ id: 1, customerRepId: 2 });
+
+      const result = await executeAction(
+        salesRepAction({ applyToAllUnassigned: true }),
+        { id: 999 } // triggering order ignored in backfill mode
+      );
+
+      expect(prismaMock.order.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { customerRepId: null } })
+      );
+      expect(prismaMock.order.update).toHaveBeenCalledTimes(2);
+      expect(result.assigned).toBe(2);
+    });
+  });
+});

--- a/backend/src/queues/workflowQueue.ts
+++ b/backend/src/queues/workflowQueue.ts
@@ -144,12 +144,16 @@ workflowQueue.process('execute-workflow', async (job: Bull.Job) => {
   return processJob();
 });
 
-async function executeAssignUserAction(action: any, _input: any, conditions?: any): Promise<any> {
+async function executeAssignUserAction(action: any, input: any, conditions?: any): Promise<any> {
   const config = action.config || {};
   const userType = config.userType; // 'sales_rep' | 'delivery_agent'
   const distributionMode = config.distributionMode || 'even';
   const assignments = config.assignments || [];
-  const onlyUnassigned = config.onlyUnassigned !== undefined ? config.onlyUnassigned : true;
+  // Backfill is opt-in and OFF by default. When false (the default), this action is
+  // forward-only: it assigns ONLY the order that triggered the workflow. When true, it
+  // performs a one-time sweep of every order currently unassigned for this role.
+  // In BOTH modes it never overwrites an order that already has a user (no swapping).
+  const applyToAllUnassigned = config.applyToAllUnassigned === true;
 
   // Determine which field to update
   const targetField = userType === 'sales_rep' ? 'customerRepId' : 'deliveryAgentId';
@@ -158,29 +162,46 @@ async function executeAssignUserAction(action: any, _input: any, conditions?: an
     userType,
     distributionMode,
     assignmentsCount: assignments.length,
-    onlyUnassigned,
+    applyToAllUnassigned,
     hasConditions: !!conditions
   });
 
-  // Find orders that need assignment - include product data for condition evaluation
-  const whereClause: any = {};
-  if (onlyUnassigned) {
-    whereClause[targetField] = null;
+  if (assignments.length === 0) {
+    return { assigned: 0, message: 'No users configured for assignment' };
   }
 
-  const orders = await prisma.order.findMany({
-    where: whereClause,
-    include: {
-      orderItems: {
-        include: {
-          product: true
-        }
-      }
-    },
-    orderBy: { createdAt: 'asc' }
-  });
+  const orderInclude = { orderItems: { include: { product: true } } };
+  let orders: any[];
 
-  logger.info(`Found ${orders.length} unassigned orders to check`);
+  if (applyToAllUnassigned) {
+    // One-time backfill (explicit opt-in): every order currently unassigned for this role.
+    orders = await prisma.order.findMany({
+      where: { [targetField]: null } as any,
+      include: orderInclude,
+      orderBy: { createdAt: 'asc' }
+    });
+    logger.info(`assign_user backfill: found ${orders.length} unassigned orders`);
+  } else {
+    // Forward-only (default): act ONLY on the order that triggered this workflow.
+    const triggerOrderId = input?.orderId ?? input?.id;
+    if (!triggerOrderId) {
+      logger.info('assign_user forward-only: no triggering order in context, nothing to do');
+      return { assigned: 0, message: 'Forward-only assign_user: no triggering order in context' };
+    }
+    const order = await prisma.order.findUnique({
+      where: { id: triggerOrderId },
+      include: orderInclude
+    });
+    if (!order) {
+      return { assigned: 0, message: `Forward-only assign_user: order ${triggerOrderId} not found` };
+    }
+    // Never swap: leave an order that already has a user for this role untouched.
+    if ((order as any)[targetField] != null) {
+      logger.info('assign_user forward-only: order already assigned, leaving as-is', { orderId: triggerOrderId, userType });
+      return { assigned: 0, message: 'Order already has an assigned user; left unchanged' };
+    }
+    orders = [order];
+  }
 
   if (orders.length === 0) {
     return { assigned: 0, message: 'No orders found to assign' };

--- a/frontend/src/components/workflows/actions/AssignUserAction.tsx
+++ b/frontend/src/components/workflows/actions/AssignUserAction.tsx
@@ -13,7 +13,7 @@ export interface AssignUserConfig {
   userType: 'sales_rep' | 'delivery_agent';
   assignments: UserAssignment[];
   distributionMode: 'even' | 'weighted';
-  onlyUnassigned: boolean;
+  applyToAllUnassigned: boolean;
 }
 
 interface AssignUserActionProps {
@@ -397,23 +397,25 @@ export const AssignUserAction: React.FC<AssignUserActionProps> = ({
         </div>
       )}
 
-      {/* Only Unassigned Option */}
+      {/* Backfill opt-in. Off (default) = forward-only: assign only new orders
+          going forward. Orders that already have a user are never overwritten
+          in either mode. */}
       <div className="flex items-start gap-3 p-4 bg-gray-50 rounded-lg">
         <input
           type="checkbox"
-          id="onlyUnassigned"
-          checked={config.onlyUnassigned}
+          id="applyToAllUnassigned"
+          checked={config.applyToAllUnassigned}
           onChange={(e) =>
-            onChange({ ...config, onlyUnassigned: e.target.checked })
+            onChange({ ...config, applyToAllUnassigned: e.target.checked })
           }
           className="mt-1 h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
         />
-        <label htmlFor="onlyUnassigned" className="flex-1">
+        <label htmlFor="applyToAllUnassigned" className="flex-1">
           <div className="text-sm font-medium text-gray-900">
-            Only apply to unassigned orders
+            Apply to all unassigned orders
           </div>
           <div className="text-xs text-gray-600 mt-1">
-            Skip orders that already have an assigned user
+            One-time backfill: assign every existing unassigned order now. Leave off to only assign new orders going forward.
           </div>
         </label>
       </div>

--- a/frontend/src/components/workflows/steps/ActionsStep.tsx
+++ b/frontend/src/components/workflows/steps/ActionsStep.tsx
@@ -87,7 +87,7 @@ export const ActionsStep: React.FC<ActionsStepProps> = ({
         userType: 'sales_rep',
         assignments: [],
         distributionMode: 'even',
-        onlyUnassigned: true,
+        applyToAllUnassigned: false,
       };
     } else if (actionType === 'send_whatsapp') {
       defaultConfig = {

--- a/frontend/src/examples/WorkflowBuilderDemo.tsx
+++ b/frontend/src/examples/WorkflowBuilderDemo.tsx
@@ -31,7 +31,7 @@ export const WorkflowBuilderDemo: React.FC = () => {
     userType: 'sales_rep',
     assignments: [],
     distributionMode: 'even',
-    onlyUnassigned: true,
+    applyToAllUnassigned: false,
   });
 
   const handleSaveWorkflow = () => {

--- a/frontend/src/pages/WorkflowEditor.tsx
+++ b/frontend/src/pages/WorkflowEditor.tsx
@@ -99,7 +99,7 @@ export const WorkflowEditor: React.FC = () => {
         userType: 'sales_rep',
         assignments: [],
         distributionMode: 'even',
-        onlyUnassigned: true,
+        applyToAllUnassigned: false,
       };
     } else if (actionType === 'send_whatsapp') {
       defaultConfig = {


### PR DESCRIPTION
Promotes `develop` → `main` for production deploy.

## Headline change
**fix(workflows): assign_user forward-only by default, backfill opt-in** (#267)
- `assign_user` no longer sweeps every unassigned order tenant-wide on each run. It now assigns only the triggering order by default.
- Never swaps an order that already has a user for that role.
- One-time backfill is opt-in via the `applyToAllUnassigned` flag / "Apply to all unassigned orders" toggle.
- Existing saved workflows default to forward-only — no DB migration, no silent backfill.
- Regression tests added; full CI green on #267.

Also includes any other changes already merged into `develop` since the last release.

## Prod data note
The one-time data cleanup (2,819 mis-assigned orders reverted) was already applied to production out-of-band; rollback snapshot retained in `rep2_flood_revert_bak_20260705`. This release carries the code fix that prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)