### PR TITLE
feat(mcp): add orders_update_status write tool

### DIFF
--- a/backend/src/__tests__/integration/mcpOrdersUpdateStatus.test.ts
+++ b/backend/src/__tests__/integration/mcpOrdersUpdateStatus.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Integration tests for the MCP `orders_update_status` write tool.
+ *
+ * Exercises the real handler (updateOrderStatusTool) against a live test DB,
+ * inside a tenant context, proving:
+ *   - a real status change delegates to orderService and writes an audit row
+ *   - the idempotency guard makes no change (and no new history) when already set
+ *   - unknown orders return a clean error
+ *   - the tenant-isolation extension makes cross-tenant updates impossible
+ *
+ * Uses `confirmed -> preparing`: a transition that touches neither inventory
+ * (deducted zone is out_for_delivery/delivered) nor the GL (returned only),
+ * so assertions stay deterministic.
+ */
+
+import { jest, describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { prismaBase } from '../../utils/prisma';
+import { tenantStorage } from '../../utils/tenantContext';
+import { updateOrderStatusTool } from '../../mcp/tools/ordersWrite';
+
+// orderService may emit socket events / log — stub both, as the other
+// integration suites do.
+jest.mock('../../utils/socketInstance', () => ({
+  setSocketInstance: jest.fn(),
+  getSocketInstance: jest.fn(() => ({
+    to: jest.fn(() => ({ emit: jest.fn() })),
+    emit: jest.fn(),
+  })),
+  hasSocketInstance: jest.fn(() => true),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+const SUFFIX = Date.now();
+
+let tenantAId: string;
+let tenantBId: string;
+let orderAId: number;
+let orderBId: number;
+
+// Parse the JSON payload an MCP tool returns in content[0].text.
+function payload(res: any) {
+  return JSON.parse(res.content[0].text);
+}
+// Run a tool call inside a given tenant's context.
+function asTenant<T>(tenantId: string, fn: () => Promise<T>): Promise<T> {
+  return tenantStorage.run({ tenantId }, fn);
+}
+
+beforeAll(async () => {
+  const [tenantA, tenantB] = await Promise.all([
+    prismaBase.tenant.create({ data: { name: `MCP Tenant A ${SUFFIX}`, slug: `mcp-a-${SUFFIX}` } }),
+    prismaBase.tenant.create({ data: { name: `MCP Tenant B ${SUFFIX}`, slug: `mcp-b-${SUFFIX}` } }),
+  ]);
+  tenantAId = tenantA.id;
+  tenantBId = tenantB.id;
+
+  const [custA, custB] = await Promise.all([
+    prismaBase.customer.create({
+      data: {
+        firstName: 'Ama', lastName: 'Mensah',
+        phoneNumber: `+2331${SUFFIX}`.slice(0, 15),
+        address: '1 Test St', state: 'Greater Accra', area: 'Accra', tenantId: tenantAId,
+      },
+    }),
+    prismaBase.customer.create({
+      data: {
+        firstName: 'Bola', lastName: 'Ade',
+        phoneNumber: `+2332${SUFFIX}`.slice(0, 15),
+        address: '2 Test St', state: 'Greater Accra', area: 'Accra', tenantId: tenantBId,
+      },
+    }),
+  ]);
+
+  const [orderA, orderB] = await Promise.all([
+    prismaBase.order.create({
+      data: {
+        customerId: custA.id, status: 'confirmed',
+        subtotal: 100, shippingCost: 0, totalAmount: 100,
+        deliveryAddress: '1 Test St', deliveryState: 'Greater Accra', deliveryArea: 'Accra',
+        tenantId: tenantAId,
+      },
+    }),
+    prismaBase.order.create({
+      data: {
+        customerId: custB.id, status: 'confirmed',
+        subtotal: 100, shippingCost: 0, totalAmount: 100,
+        deliveryAddress: '2 Test St', deliveryState: 'Greater Accra', deliveryArea: 'Accra',
+        tenantId: tenantBId,
+      },
+    }),
+  ]);
+  orderAId = orderA.id;
+  orderBId = orderB.id;
+});
+
+afterAll(async () => {
+  const ids = [tenantAId, tenantBId];
+  await prismaBase.orderHistory.deleteMany({ where: { order: { tenantId: { in: ids } } } });
+  await prismaBase.order.deleteMany({ where: { tenantId: { in: ids } } });
+  await prismaBase.customer.deleteMany({ where: { tenantId: { in: ids } } });
+  await prismaBase.tenant.deleteMany({ where: { id: { in: ids } } });
+  await prismaBase.$disconnect();
+});
+
+describe('orders_update_status MCP tool', () => {
+  it('updates status, returns previous/new, and writes an OrderHistory row', async () => {
+    const res = await asTenant(tenantAId, () =>
+      updateOrderStatusTool({ orderId: orderAId, status: 'preparing' }),
+    );
+    const body = payload(res);
+
+    expect(res.isError).toBeUndefined();
+    expect(body).toMatchObject({
+      updated: true,
+      orderId: orderAId,
+      previousStatus: 'confirmed',
+      newStatus: 'preparing',
+      customer: 'Ama Mensah',
+    });
+
+    const dbOrder = await prismaBase.order.findUnique({ where: { id: orderAId } });
+    expect(dbOrder?.status).toBe('preparing');
+
+    const history = await prismaBase.orderHistory.findMany({
+      where: { orderId: orderAId, status: 'preparing' },
+    });
+    expect(history.length).toBe(1);
+  });
+
+  it('is idempotent: no change and no new history when already in target status', async () => {
+    const before = await prismaBase.orderHistory.count({ where: { orderId: orderAId } });
+
+    const res = await asTenant(tenantAId, () =>
+      updateOrderStatusTool({ orderId: orderAId, status: 'preparing' }),
+    );
+    const body = payload(res);
+
+    expect(res.isError).toBeUndefined();
+    expect(body.updated).toBe(false);
+    expect(body.message).toMatch(/already/i);
+
+    const after = await prismaBase.orderHistory.count({ where: { orderId: orderAId } });
+    expect(after).toBe(before);
+  });
+
+  it('returns an error for an unknown order', async () => {
+    const res = await asTenant(tenantAId, () =>
+      updateOrderStatusTool({ orderId: 999_999_999, status: 'delivered' }),
+    );
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/not found/i);
+  });
+
+  it('cannot update an order that belongs to another tenant', async () => {
+    // Tenant A context, targeting Tenant B's order.
+    const res = await asTenant(tenantAId, () =>
+      updateOrderStatusTool({ orderId: orderBId, status: 'cancelled' }),
+    );
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/not found/i);
+
+    // Tenant B's order is untouched.
+    const orderB = await prismaBase.order.findUnique({ where: { id: orderBId } });
+    expect(orderB?.status).toBe('confirmed');
+  });
+});

--- a/backend/src/mcp/createServer.ts
+++ b/backend/src/mcp/createServer.ts
@@ -7,6 +7,7 @@ import { mcpError } from './utils';
 
 // Import tool registrations
 import { registerOrderTools } from './tools/orders';
+import { registerOrderWriteTools } from './tools/ordersWrite';
 import { registerAnalyticsTools } from './tools/analytics';
 import { registerAgentTools } from './tools/agents';
 import { registerDeliveryTools } from './tools/deliveries';
@@ -46,6 +47,7 @@ export function createMcpServer(resolveApiKey: () => string) {
   }
 
   registerOrderTools(server, wrapHandler);
+  registerOrderWriteTools(server, wrapHandler);
   registerAnalyticsTools(server, wrapHandler);
   registerAgentTools(server, wrapHandler);
   registerDeliveryTools(server, wrapHandler);

--- a/backend/src/mcp/tools/ordersWrite.ts
+++ b/backend/src/mcp/tools/ordersWrite.ts
@@ -1,0 +1,102 @@
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import prisma from '../../utils/prisma';
+import orderService from '../../services/orderService';
+import { mcpJson, mcpError } from '../utils';
+
+// Mirror of the app's own dashboard whitelist (see utils/validators.ts
+// updateOrderStatusValidation): the MCP tool grants exactly the status
+// transitions a human admin can make from the UI — no more, no less.
+const ordersUpdateStatusSchema = z.object({
+  orderId: z.number().int().positive(),
+  status: z.enum([
+    'pending_confirmation',
+    'confirmed',
+    'preparing',
+    'ready_for_pickup',
+    'out_for_delivery',
+    'delivered',
+    'cancelled',
+    'returned',
+    'failed_delivery',
+  ]),
+  notes: z.string().max(500).optional(),
+});
+
+/**
+ * Handler for the `orders_update_status` tool. Exported for direct testing.
+ * MUST run inside a tenant context (set by the MCP server's wrapHandler), so
+ * that the tenant-isolation Prisma extension scopes every query.
+ */
+export async function updateOrderStatusTool(args: z.infer<typeof ordersUpdateStatusSchema>) {
+  try {
+    const parsed = ordersUpdateStatusSchema.parse(args);
+
+    // Tenant-scoped lookup. findFirst passes through the tenant-isolation
+    // Prisma extension, so an orderId belonging to another tenant simply
+    // returns null — this tool can never mutate another store's order.
+    const existing = await prisma.order.findFirst({
+      where: { id: parsed.orderId, deletedAt: null },
+      include: {
+        customer: { select: { firstName: true, lastName: true, phoneNumber: true } },
+      },
+    });
+
+    if (!existing) {
+      return mcpError(`Order ${parsed.orderId} not found`);
+    }
+
+    const customerName = existing.customer
+      ? `${existing.customer.firstName} ${existing.customer.lastName}`
+      : null;
+    const customerPhone = existing.customer?.phoneNumber ?? null;
+
+    // Idempotency guard: never re-run the status side effects (inventory
+    // movement, GL reversal, payment collection) when the order is already
+    // in the requested status. Safe to call the tool repeatedly.
+    if (existing.status === parsed.status) {
+      return mcpJson({
+        updated: false,
+        orderId: parsed.orderId,
+        status: existing.status,
+        customer: customerName,
+        customerPhone,
+        message: `Order already in status "${parsed.status}"; no change made.`,
+      });
+    }
+
+    const previousStatus = existing.status;
+
+    // Delegate to the shared service so inventory, delivery date,
+    // paymentStatus, GL journal reversal, and the OrderHistory audit row are
+    // all handled consistently with the normal app flow. No `requester` is
+    // passed: the MCP key is tenant-scoped, not user-scoped.
+    await orderService.updateOrderStatus(parsed.orderId, {
+      status: parsed.status,
+      notes: parsed.notes ?? 'Status updated via MCP',
+    });
+
+    return mcpJson({
+      updated: true,
+      orderId: parsed.orderId,
+      previousStatus,
+      newStatus: parsed.status,
+      customer: customerName,
+      customerPhone,
+    });
+  } catch (err) {
+    return mcpError((err as Error).message);
+  }
+}
+
+export function registerOrderWriteTools(
+  server: McpServer,
+  wrapHandler: <T>(handler: (args: T) => Promise<any>) => (args: T) => Promise<any>,
+) {
+  server.tool(
+    'orders_update_status',
+    'Update an order\'s fulfillment status. Writes an order-history audit row and, via the shared order service, adjusts inventory and (on delivered/returned) payment status and accounting entries. Idempotent: makes no change if the order is already in the requested status. Valid statuses: pending_confirmation, confirmed, preparing, ready_for_pickup, out_for_delivery, delivered, cancelled, returned, failed_delivery.',
+    ordersUpdateStatusSchema.shape,
+    wrapHandler(updateOrderStatusTool),
+  );
+}


### PR DESCRIPTION
## What

Adds a single write tool to the CodAdmin MCP server: **`orders_update_status`**. Until now the MCP exposed 13 read-only tools — this is the first tool that can mutate an order, added so order fulfilment statuses can be reconciled against 3PL delivery-portal data without hand-editing each order in the UI.

## How it's safe

- **Delegates to `orderService.updateOrderStatus`** — no raw writes. Inventory movement, delivery date, `paymentStatus` (collected on delivered), GL journal reversal (on returned), and the `OrderHistory` audit row all run exactly as they do from the admin UI.
- **Tenant-scoped.** Lookup uses `prisma.order.findFirst` through the tenant-isolation extension, so an `orderId` belonging to another store returns "not found" — the tool can never mutate another tenant's order. Covered by a test.
- **Idempotent.** If the order is already in the requested status, it makes no change and writes no history — safe to re-run a weekly reconciliation.
- **Whitelisted statuses** mirror the app's own `updateOrderStatusValidation` — no transitions a human admin couldn't make.

## Tests

New integration suite `mcpOrdersUpdateStatus.test.ts` (4/4 passing against the test DB):
1. Real change returns previous/new status + writes one `OrderHistory` row
2. Idempotent no-op when already in target status (no new history)
3. Unknown order → clean error
4. Cross-tenant update blocked (Tenant A context cannot touch Tenant B's order)

Local verification: `tsc` clean, backend `eslint` clean.

## Files
- `backend/src/mcp/tools/ordersWrite.ts` (new)
- `backend/src/mcp/createServer.ts` (registers the tool)
- `backend/src/__tests__/integration/mcpOrdersUpdateStatus.test.ts` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)