### PR TITLE
Multi-store: Owner-plumbing lane (MAN-108, MAN-92..99)

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -34,6 +34,14 @@ model Tenant {
   // cannot be deleted while the tenant still points at them. Both delete paths
   // (self-serve deleteTenantAccount, platform deleteTenant) release this ref
   // (owner_user_id = NULL) before deleting users, so tenant deletion still works.
+  //
+  // MAN-96 — INVARIANT (zero-User-row tenant): a tenant MAY have zero User rows
+  // whose user.tenantId points at it. An owner is a User with a StoreMembership to
+  // this tenant, but their own user.tenantId is null (owners) or another store's.
+  // Therefore the owner is resolved ONLY via this ownerUserId FK — never by a
+  // (tenantId, role) scan and never by assuming a tenant-scoped owner User row.
+  // All owner-resolution paths (platformService, notificationService) honor this;
+  // do not reintroduce owner-by-tenantId lookups.
   ownerUserId               Int?      @map("owner_user_id")
   createdAt                 DateTime  @default(now())
   updatedAt                 DateTime  @updatedAt

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -125,6 +125,12 @@ model User {
   isPlatformAdmin       Boolean             @default(false) @map("is_platform_admin")
   isAvailable           Boolean             @default(true) @map("is_available")
   lastLogin             DateTime?           @map("last_login")
+  // MAN-97 — DECISION (single-active-session, v1): one refresh-token slot per
+  // user. Switching stores (POST /stores/switch) or logging in elsewhere
+  // overwrites it, invalidating the prior session. This is an accepted v1
+  // limitation, NOT true multi-store concurrency — a store owner cannot hold two
+  // stores open in two tabs at once. True concurrency needs a sessions table
+  // (deferred, not in v1 scope); do not add one without an explicit decision.
   refreshToken          String?             @map("refresh_token")
   passwordResetToken    String?             @unique @map("password_reset_token")
   passwordResetExpires  DateTime?           @map("password_reset_expires")

--- a/backend/src/__tests__/integration/authIdentity.test.ts
+++ b/backend/src/__tests__/integration/authIdentity.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Identity carve-out for me / logout / refresh (MAN-93)
+ *
+ * me and logout ran through the tenant-scoped client, so for a null-tenant owner
+ * (active store != their null User.tenantId) the reads missed and logout's
+ * refresh-token clear silently matched zero rows — logout was a lie. me/logout
+ * now use the unscoped identity carve-out; refresh routes through mintTokens.
+ */
+
+import { jest, describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import request from 'supertest';
+import app from '../../server';
+import { prismaBase } from '../../utils/prisma';
+import { generateAccessToken, generateRefreshToken } from '../../utils/jwt';
+
+jest.mock('../../utils/socketInstance', () => ({
+  setSocketInstance: jest.fn(),
+  getSocketInstance: jest.fn(() => ({ to: jest.fn(() => ({ emit: jest.fn() })), emit: jest.fn() })),
+  hasSocketInstance: jest.fn(() => true),
+}));
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+const SUFFIX = Date.now();
+
+let storeId: string;
+let ownerId: number;
+let ownerEmail: string;
+let accessToken: string;   // active store = storeId, but owner's User.tenantId is null
+let refreshTok: string;
+
+beforeAll(async () => {
+  const store = await prismaBase.tenant.create({ data: { name: `S ${SUFFIX}`, slug: `s-${SUFFIX}`, subscriptionStatus: 'active' } });
+  storeId = store.id;
+  ownerEmail = `id-owner-${SUFFIX}@test.com`;
+
+  const owner = await prismaBase.user.create({
+    data: { email: ownerEmail, password: 'x', role: 'super_admin', firstName: 'Id', lastName: 'Owner', tenantId: null },
+  });
+  ownerId = owner.id;
+
+  await prismaBase.storeMembership.create({ data: { userId: ownerId, tenantId: storeId, role: 'super_admin', isDefault: true } });
+
+  accessToken = generateAccessToken({ id: ownerId, email: ownerEmail, role: 'super_admin', tenantId: storeId });
+  refreshTok = generateRefreshToken({ id: ownerId, email: ownerEmail, role: 'super_admin', tenantId: storeId });
+  await prismaBase.user.update({ where: { id: ownerId }, data: { refreshToken: refreshTok } });
+});
+
+afterAll(async () => {
+  await prismaBase.storeMembership.deleteMany({ where: { userId: ownerId } });
+  await prismaBase.user.deleteMany({ where: { id: ownerId } });
+  await prismaBase.tenant.deleteMany({ where: { id: storeId } });
+  await prismaBase.$disconnect();
+});
+
+describe('me / logout / refresh identity carve-out (null-tenant owner)', () => {
+  it('me resolves the null-tenant owner\'s own row', async () => {
+    const res = await request(app).get('/api/auth/me').set('Authorization', `Bearer ${accessToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.user.id).toBe(ownerId);
+    expect(res.body.user.email).toBe(ownerEmail);
+  });
+
+  it('refresh goes through mintTokens and returns a new access token', async () => {
+    const res = await request(app).post('/api/auth/refresh').send({ refreshToken: refreshTok });
+    expect(res.status).toBe(200);
+    expect(typeof res.body.accessToken).toBe('string');
+  });
+
+  it('logout clears the refresh token for a null-tenant owner (no silent no-op)', async () => {
+    const res = await request(app).post('/api/auth/logout').set('Authorization', `Bearer ${accessToken}`);
+    expect(res.status).toBe(200);
+    const after = await prismaBase.user.findFirst({ where: { id: ownerId }, select: { refreshToken: true } });
+    expect(after?.refreshToken).toBeNull();
+  });
+});

--- a/backend/src/__tests__/integration/notifyOverdueOwner.test.ts
+++ b/backend/src/__tests__/integration/notifyOverdueOwner.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Overdue-collections notify routes to the store OWNER (MAN-95)
+ *
+ * The aging cron runs cross-tenant. It used to notify every admin/super_admin
+ * across every tenant — store A's collections leaked to store B's admins. It now
+ * groups overdue agents by store and pages that store's owner resolved by the
+ * Tenant.ownerUserId FK. This test proves each owner is notified only about their
+ * own store's agents, and a non-owner admin is not notified at all.
+ */
+
+import { jest, describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { prismaBase } from '../../utils/prisma';
+import { notifyAdminsOverdueCollections } from '../../services/notificationService';
+
+jest.mock('../../utils/socketInstance', () => ({
+  setSocketInstance: jest.fn(),
+  getSocketInstance: jest.fn(() => ({ to: jest.fn(() => ({ emit: jest.fn() })), emit: jest.fn() })),
+  hasSocketInstance: jest.fn(() => true),
+}));
+jest.mock('../../sockets', () => ({ emitNotification: jest.fn() }));
+
+const SUFFIX = Date.now();
+
+let tenantAId: string; let tenantBId: string;
+let ownerAId: number; let ownerBId: number; let adminAId: number;
+
+beforeAll(async () => {
+  const [ta, tb] = await Promise.all([
+    prismaBase.tenant.create({ data: { name: `A ${SUFFIX}`, slug: `a-${SUFFIX}`, subscriptionStatus: 'active' } }),
+    prismaBase.tenant.create({ data: { name: `B ${SUFFIX}`, slug: `b-${SUFFIX}`, subscriptionStatus: 'active' } }),
+  ]);
+  tenantAId = ta.id; tenantBId = tb.id;
+
+  const ownerA = await prismaBase.user.create({ data: { email: `oa-${SUFFIX}@t.com`, password: 'x', role: 'super_admin', firstName: 'OA', lastName: 'X', tenantId: null } });
+  const ownerB = await prismaBase.user.create({ data: { email: `ob-${SUFFIX}@t.com`, password: 'x', role: 'super_admin', firstName: 'OB', lastName: 'X', tenantId: null } });
+  const adminA = await prismaBase.user.create({ data: { email: `aa-${SUFFIX}@t.com`, password: 'x', role: 'admin', firstName: 'AA', lastName: 'X', tenantId: tenantAId } });
+  ownerAId = ownerA.id; ownerBId = ownerB.id; adminAId = adminA.id;
+
+  await prismaBase.tenant.update({ where: { id: tenantAId }, data: { ownerUserId: ownerAId } });
+  await prismaBase.tenant.update({ where: { id: tenantBId }, data: { ownerUserId: ownerBId } });
+});
+
+afterAll(async () => {
+  await prismaBase.notification.deleteMany({ where: { userId: { in: [ownerAId, ownerBId, adminAId] } } });
+  // Null owner FK before deleting users (ownerUserId is onDelete: Restrict).
+  await prismaBase.tenant.updateMany({ where: { id: { in: [tenantAId, tenantBId] } }, data: { ownerUserId: null } });
+  await prismaBase.user.deleteMany({ where: { id: { in: [ownerAId, ownerBId, adminAId] } } });
+  await prismaBase.tenant.deleteMany({ where: { id: { in: [tenantAId, tenantBId] } } });
+  await prismaBase.$disconnect();
+});
+
+describe('notifyAdminsOverdueCollections (owner-scoped)', () => {
+  it('pages each store owner about their OWN agents, and not a non-owner admin', async () => {
+    await notifyAdminsOverdueCollections([
+      { agentId: 1, tenantId: tenantAId, agentName: 'Agent A1', totalBalance: 100, warningAmount: 100, criticalAmount: 0 },
+      { agentId: 2, tenantId: tenantBId, agentName: 'Agent B1', totalBalance: 200, warningAmount: 0, criticalAmount: 200 },
+    ]);
+
+    const [aNotes, bNotes, adminNotes] = await Promise.all([
+      prismaBase.notification.findMany({ where: { userId: ownerAId, type: 'overdue_collections' } }),
+      prismaBase.notification.findMany({ where: { userId: ownerBId, type: 'overdue_collections' } }),
+      prismaBase.notification.findMany({ where: { userId: adminAId, type: 'overdue_collections' } }),
+    ]);
+
+    expect(aNotes).toHaveLength(1);
+    expect(aNotes[0].message).toContain('Agent A1');
+    expect(aNotes[0].message).not.toContain('Agent B1'); // no cross-store leak
+    expect(bNotes).toHaveLength(1);
+    expect(bNotes[0].message).toContain('Agent B1');
+    expect(adminNotes).toHaveLength(0); // non-owner admin is not paged
+  });
+});

--- a/backend/src/__tests__/integration/onboardingGate.test.ts
+++ b/backend/src/__tests__/integration/onboardingGate.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Onboarding auto-create gate (MAN-94)
+ *
+ * setupOnboarding auto-creates a "company-N" tenant for a user with no tenant.
+ * A multi-store OWNER is legitimately null-tenant (they provision via the
+ * platform console) and always has a StoreMembership — so the auto-create must
+ * be gated OFF for them, or a stray tenant is minted on every onboarding hit.
+ */
+
+import { jest, describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import request from 'supertest';
+import app from '../../server';
+import { prismaBase } from '../../utils/prisma';
+import { generateAccessToken } from '../../utils/jwt';
+
+jest.mock('../../utils/socketInstance', () => ({
+  setSocketInstance: jest.fn(),
+  getSocketInstance: jest.fn(() => ({ to: jest.fn(() => ({ emit: jest.fn() })), emit: jest.fn() })),
+  hasSocketInstance: jest.fn(() => true),
+}));
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+const SUFFIX = Date.now();
+
+let storeId: string;
+let ownerId: number;
+let tokenNull: string; // owner token carrying a NULL active tenant
+
+beforeAll(async () => {
+  const store = await prismaBase.tenant.create({ data: { name: `S ${SUFFIX}`, slug: `s-${SUFFIX}`, subscriptionStatus: 'active' } });
+  storeId = store.id;
+
+  const owner = await prismaBase.user.create({
+    data: { email: `gate-owner-${SUFFIX}@test.com`, password: 'x', role: 'super_admin', firstName: 'Gate', lastName: 'Owner', tenantId: null },
+  });
+  ownerId = owner.id;
+  await prismaBase.storeMembership.create({ data: { userId: ownerId, tenantId: storeId, role: 'super_admin', isDefault: true } });
+
+  tokenNull = generateAccessToken({ id: ownerId, email: owner.email, role: 'super_admin', tenantId: null as any });
+});
+
+afterAll(async () => {
+  // Defensive: if the gate ever regressed and a stray tenant WAS created, clean it too.
+  const stray = await prismaBase.tenant.findFirst({ where: { slug: `company-${ownerId}` } });
+  await prismaBase.storeMembership.deleteMany({ where: { userId: ownerId } });
+  await prismaBase.user.deleteMany({ where: { id: ownerId } });
+  const tenantIds = [storeId, ...(stray ? [stray.id] : [])];
+  await prismaBase.tenant.deleteMany({ where: { id: { in: tenantIds } } });
+  await prismaBase.$disconnect();
+});
+
+describe('onboarding auto-create gate (null-tenant owner)', () => {
+  it('does NOT auto-create a stray tenant for a null-tenant owner with a membership', async () => {
+    await request(app)
+      .post('/api/onboarding/setup')
+      .set('Authorization', `Bearer ${tokenNull}`)
+      .send({ country: 'NG', currency: 'NGN' });
+
+    const stray = await prismaBase.tenant.findFirst({ where: { slug: `company-${ownerId}` } });
+    expect(stray).toBeNull();
+  });
+});

--- a/backend/src/__tests__/integration/platformAuth.test.ts
+++ b/backend/src/__tests__/integration/platformAuth.test.ts
@@ -1,0 +1,84 @@
+/**
+ * platformAuth owner-resolution + zero-store bootstrap (MAN-92)
+ *
+ * requirePlatformAdmin resolved the admin's User row through the tenant-scoped
+ * (extended) client while the caller's active-store tenant was still in context.
+ * An owner in platform mode (User.tenantId = null, holding some other store's
+ * active tenant) was therefore not found -> 403, locking owners — including
+ * brand-new zero-store owners — out of the provisioning console.
+ *
+ * Fix: resolve identity through prismaBase (unscoped) BEFORE nullifying tenant
+ * context. These tests prove a null-tenant platform admin reaches the console and
+ * a non-admin is still forbidden.
+ */
+
+import { jest, describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import request from 'supertest';
+import app from '../../server';
+import { prismaBase } from '../../utils/prisma';
+import { generateAccessToken } from '../../utils/jwt';
+
+jest.mock('../../utils/socketInstance', () => ({
+  setSocketInstance: jest.fn(),
+  getSocketInstance: jest.fn(() => ({ to: jest.fn(() => ({ emit: jest.fn() })), emit: jest.fn() })),
+  hasSocketInstance: jest.fn(() => true),
+}));
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+const SUFFIX = Date.now();
+const ROUTE = '/api/platform/tenants';
+
+let storeId: string;
+let adminId: number;
+let nonAdminId: number;
+let adminToken: string;   // platform admin, User.tenantId = null, token carries another store
+let nonAdminToken: string;
+
+beforeAll(async () => {
+  const store = await prismaBase.tenant.create({ data: { name: `Store ${SUFFIX}`, slug: `store-${SUFFIX}`, subscriptionStatus: 'active' } });
+  storeId = store.id;
+
+  // Owner in platform mode: isPlatformAdmin, but User.tenantId is null.
+  const admin = await prismaBase.user.create({
+    data: {
+      email: `padmin-${SUFFIX}@test.com`, password: 'x', role: 'super_admin',
+      firstName: 'Plat', lastName: 'Admin', tenantId: null, isPlatformAdmin: true,
+    },
+  });
+  adminId = admin.id;
+
+  const nonAdmin = await prismaBase.user.create({
+    data: {
+      email: `nonadmin-${SUFFIX}@test.com`, password: 'x', role: 'super_admin',
+      firstName: 'Non', lastName: 'Admin', tenantId: storeId, isPlatformAdmin: false,
+    },
+  });
+  nonAdminId = nonAdmin.id;
+
+  // The admin's token carries an active store even though their User row is
+  // null-tenant — this is exactly what the scoped lookup used to trip on.
+  adminToken = generateAccessToken({ id: adminId, email: admin.email, role: 'super_admin', tenantId: storeId });
+  nonAdminToken = generateAccessToken({ id: nonAdminId, email: nonAdmin.email, role: 'super_admin', tenantId: storeId });
+});
+
+afterAll(async () => {
+  await prismaBase.user.deleteMany({ where: { id: { in: [adminId, nonAdminId] } } });
+  await prismaBase.tenant.deleteMany({ where: { id: storeId } });
+  await prismaBase.$disconnect();
+});
+
+describe('requirePlatformAdmin (owner-resolution + zero-store bootstrap)', () => {
+  it('lets a null-tenant platform admin reach the console (not a 403 lockout)', async () => {
+    const res = await request(app).get(ROUTE).set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).not.toBe(403);
+    expect(res.status).toBe(200);
+  });
+
+  it('still forbids a non-platform-admin (403)', async () => {
+    const res = await request(app).get(ROUTE).set('Authorization', `Bearer ${nonAdminToken}`);
+    expect(res.status).toBe(403);
+  });
+});

--- a/backend/src/__tests__/integration/storeCore.test.ts
+++ b/backend/src/__tests__/integration/storeCore.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Store-core acceptance tests (MAN-108)
+ *
+ * Proves the three acceptance criteria:
+ *  1. mintTokens fails CLOSED — a user with no resolvable active store throws
+ *     403 TENANT_UNRESOLVED, never a null-tenant token.
+ *  2. GET /api/stores returns exactly the caller's StoreMembership rows.
+ *  3. POST /api/stores/switch re-mints a token scoped to an owned store, and
+ *     403s (NOT_A_MEMBER) for a store the caller does not belong to.
+ */
+
+import { jest, describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import request from 'supertest';
+import app from '../../server';
+import { prismaBase } from '../../utils/prisma';
+import { generateAccessToken, verifyAccessToken } from '../../utils/jwt';
+import { mintTokens } from '../../utils/mintTokens';
+
+jest.mock('../../utils/socketInstance', () => ({
+  setSocketInstance: jest.fn(),
+  getSocketInstance: jest.fn(() => ({ to: jest.fn(() => ({ emit: jest.fn() })), emit: jest.fn() })),
+  hasSocketInstance: jest.fn(() => true),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+const SUFFIX = Date.now();
+
+let tenantAId: string; // owner is a member (default)
+let tenantBId: string; // owner is a member (non-default)
+let tenantCId: string; // owner is NOT a member
+let ownerId: number;
+let orphanId: number; // user with null tenantId and no membership
+let ownerToken: string;
+
+beforeAll(async () => {
+  const [a, b, c] = await Promise.all([
+    prismaBase.tenant.create({ data: { name: `A ${SUFFIX}`, slug: `a-${SUFFIX}`, subscriptionStatus: 'active' } }),
+    prismaBase.tenant.create({ data: { name: `B ${SUFFIX}`, slug: `b-${SUFFIX}`, subscriptionStatus: 'active' } }),
+    prismaBase.tenant.create({ data: { name: `C ${SUFFIX}`, slug: `c-${SUFFIX}`, subscriptionStatus: 'active' } }),
+  ]);
+  tenantAId = a.id; tenantBId = b.id; tenantCId = c.id;
+
+  const owner = await prismaBase.user.create({
+    data: {
+      email: `owner-${SUFFIX}@test.com`, password: 'x', role: 'super_admin',
+      firstName: 'Own', lastName: 'Er', tenantId: tenantAId,
+    },
+  });
+  ownerId = owner.id;
+
+  const orphan = await prismaBase.user.create({
+    data: {
+      email: `orphan-${SUFFIX}@test.com`, password: 'x', role: 'super_admin',
+      firstName: 'Or', lastName: 'Phan', tenantId: null,
+    },
+  });
+  orphanId = orphan.id;
+
+  await prismaBase.storeMembership.createMany({
+    data: [
+      { userId: ownerId, tenantId: tenantAId, role: 'super_admin', isDefault: true },
+      { userId: ownerId, tenantId: tenantBId, role: 'super_admin', isDefault: false },
+    ],
+  });
+
+  ownerToken = generateAccessToken({ id: ownerId, email: owner.email, role: 'super_admin', tenantId: tenantAId });
+});
+
+afterAll(async () => {
+  await prismaBase.storeMembership.deleteMany({ where: { userId: { in: [ownerId, orphanId] } } });
+  await prismaBase.user.deleteMany({ where: { id: { in: [ownerId, orphanId] } } });
+  await prismaBase.tenant.deleteMany({ where: { id: { in: [tenantAId, tenantBId, tenantCId] } } });
+  await prismaBase.$disconnect();
+});
+
+describe('mintTokens — fail closed', () => {
+  it('REFUSES to mint when no active store resolves (403 TENANT_UNRESOLVED, never a null-tenant token)', async () => {
+    await expect(
+      mintTokens({ id: orphanId, email: `orphan-${SUFFIX}@test.com`, role: 'super_admin', tenantId: null }),
+    ).rejects.toMatchObject({ statusCode: 403, errorCode: 'TENANT_UNRESOLVED' });
+  });
+
+  it('mints scoped to the default membership when user.tenantId is null but a default store exists', async () => {
+    const { tenantId } = await mintTokens({ id: ownerId, email: `owner-${SUFFIX}@test.com`, role: 'super_admin', tenantId: null });
+    expect(tenantId).toBe(tenantAId);
+  });
+});
+
+describe('GET /api/stores', () => {
+  it('returns exactly the caller\'s memberships (A and B, not C)', async () => {
+    const res = await request(app).get('/api/stores').set('Authorization', `Bearer ${ownerToken}`);
+    expect(res.status).toBe(200);
+    const ids = res.body.stores.map((s: any) => s.tenantId).sort();
+    expect(ids).toEqual([tenantAId, tenantBId].sort());
+    const active = res.body.stores.find((s: any) => s.tenantId === tenantAId);
+    expect(active.isActive).toBe(true);
+  });
+});
+
+describe('POST /api/stores/switch', () => {
+  it('re-mints a token scoped to an owned store', async () => {
+    const res = await request(app).post('/api/stores/switch').set('Authorization', `Bearer ${ownerToken}`).send({ tenantId: tenantBId });
+    expect(res.status).toBe(200);
+    expect(res.body.activeTenantId).toBe(tenantBId);
+    expect(verifyAccessToken(res.body.accessToken).tenantId).toBe(tenantBId);
+  });
+
+  it('403s (NOT_A_MEMBER) for a store the caller does not belong to', async () => {
+    const res = await request(app).post('/api/stores/switch').set('Authorization', `Bearer ${ownerToken}`).send({ tenantId: tenantCId });
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('NOT_A_MEMBER');
+  });
+});

--- a/backend/src/__tests__/integration/storeDeletion.test.ts
+++ b/backend/src/__tests__/integration/storeDeletion.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Split deletion: delete-this-store vs delete-all-account (MAN-98)
+ *
+ * DELETE /api/stores/:id removes only that store (owner + other stores survive),
+ * is owner-scoped, needs the store name + password, and refuses the last store.
+ * DELETE /api/auth/delete-account removes every OWNED store then the owner last.
+ */
+
+import { jest, describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import request from 'supertest';
+import bcrypt from 'bcrypt';
+import app from '../../server';
+import { prismaBase } from '../../utils/prisma';
+import { generateAccessToken } from '../../utils/jwt';
+
+jest.mock('../../utils/socketInstance', () => ({
+  setSocketInstance: jest.fn(),
+  getSocketInstance: jest.fn(() => ({ to: jest.fn(() => ({ emit: jest.fn() })), emit: jest.fn() })),
+  hasSocketInstance: jest.fn(() => true),
+}));
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+const SUFFIX = Date.now();
+const PASSWORD = 'secret123';
+
+let storeAId: string; let storeBId: string; let storeAName: string;
+let ownerId: number; let strangerId: number;
+let ownerToken: string; let strangerToken: string;
+
+beforeAll(async () => {
+  const hash = await bcrypt.hash(PASSWORD, 10);
+  const a = await prismaBase.tenant.create({ data: { name: `Store A ${SUFFIX}`, slug: `a-${SUFFIX}`, subscriptionStatus: 'active' } });
+  const b = await prismaBase.tenant.create({ data: { name: `Store B ${SUFFIX}`, slug: `b-${SUFFIX}`, subscriptionStatus: 'active' } });
+  storeAId = a.id; storeBId = b.id; storeAName = a.name;
+
+  const owner = await prismaBase.user.create({ data: { email: `del-owner-${SUFFIX}@t.com`, password: hash, role: 'super_admin', firstName: 'Del', lastName: 'Owner', tenantId: null } });
+  ownerId = owner.id;
+  await prismaBase.tenant.update({ where: { id: storeAId }, data: { ownerUserId: ownerId } });
+  await prismaBase.tenant.update({ where: { id: storeBId }, data: { ownerUserId: ownerId } });
+  await prismaBase.storeMembership.createMany({ data: [
+    { userId: ownerId, tenantId: storeAId, role: 'super_admin', isDefault: true },
+    { userId: ownerId, tenantId: storeBId, role: 'super_admin', isDefault: false },
+  ]});
+
+  const stranger = await prismaBase.user.create({ data: { email: `del-stranger-${SUFFIX}@t.com`, password: hash, role: 'super_admin', firstName: 'Str', lastName: 'Anger', tenantId: storeBId } });
+  strangerId = stranger.id;
+
+  ownerToken = generateAccessToken({ id: ownerId, email: owner.email, role: 'super_admin', tenantId: storeAId });
+  strangerToken = generateAccessToken({ id: strangerId, email: stranger.email, role: 'super_admin', tenantId: storeBId });
+});
+
+afterAll(async () => {
+  await prismaBase.storeMembership.deleteMany({ where: { userId: { in: [ownerId, strangerId] } } });
+  await prismaBase.tenant.updateMany({ where: { id: { in: [storeAId, storeBId] } }, data: { ownerUserId: null } });
+  await prismaBase.user.deleteMany({ where: { id: { in: [ownerId, strangerId] } } });
+  await prismaBase.tenant.deleteMany({ where: { id: { in: [storeAId, storeBId] } } });
+  await prismaBase.$disconnect();
+});
+
+describe('DELETE /api/stores/:id (delete-this-store)', () => {
+  it('rejects a wrong password (401) and does not delete', async () => {
+    const res = await request(app).delete(`/api/stores/${storeAId}`).set('Authorization', `Bearer ${ownerToken}`).send({ password: 'wrong', confirmName: storeAName });
+    expect(res.status).toBe(401);
+    expect(await prismaBase.tenant.findUnique({ where: { id: storeAId } })).not.toBeNull();
+  });
+
+  it('rejects a non-matching store name (400)', async () => {
+    const res = await request(app).delete(`/api/stores/${storeAId}`).set('Authorization', `Bearer ${ownerToken}`).send({ password: PASSWORD, confirmName: 'wrong name' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a non-owner (403)', async () => {
+    const res = await request(app).delete(`/api/stores/${storeAId}`).set('Authorization', `Bearer ${strangerToken}`).send({ password: PASSWORD, confirmName: storeAName });
+    expect(res.status).toBe(403);
+  });
+
+  it('deletes only the target store; owner and other store survive', async () => {
+    const res = await request(app).delete(`/api/stores/${storeAId}`).set('Authorization', `Bearer ${ownerToken}`).send({ password: PASSWORD, confirmName: storeAName });
+    expect(res.status).toBe(200);
+    expect(await prismaBase.tenant.findUnique({ where: { id: storeAId } })).toBeNull();
+    expect(await prismaBase.tenant.findUnique({ where: { id: storeBId } })).not.toBeNull();
+    expect(await prismaBase.user.findFirst({ where: { id: ownerId } })).not.toBeNull();
+  });
+
+  it('refuses to delete the owner\'s only remaining store (400)', async () => {
+    const bName = (await prismaBase.tenant.findUnique({ where: { id: storeBId }, select: { name: true } }))!.name;
+    const res = await request(app).delete(`/api/stores/${storeBId}`).set('Authorization', `Bearer ${ownerToken}`).send({ password: PASSWORD, confirmName: bName });
+    expect(res.status).toBe(400);
+    expect(await prismaBase.tenant.findUnique({ where: { id: storeBId } })).not.toBeNull();
+  });
+});
+
+describe('DELETE /api/auth/delete-account (delete-all)', () => {
+  it('removes every owned store and the owner last', async () => {
+    const res = await request(app).delete('/api/auth/delete-account').set('Authorization', `Bearer ${ownerToken}`).send({ password: PASSWORD });
+    expect(res.status).toBe(200);
+    expect(await prismaBase.tenant.findUnique({ where: { id: storeBId } })).toBeNull();
+    expect(await prismaBase.user.findFirst({ where: { id: ownerId } })).toBeNull();
+  });
+});

--- a/backend/src/__tests__/unit/agingService.test.ts
+++ b/backend/src/__tests__/unit/agingService.test.ts
@@ -169,8 +169,8 @@ describe('AgingService', () => {
     describe('getOverdueAgents', () => {
         it('should return agents with overdue buckets', async () => {
             const mockBuckets = [
-                { agentId: 1, totalBalance: new Prisma.Decimal(500), bucket_4_7: new Prisma.Decimal(500), bucket_8_plus: new Prisma.Decimal(0), agent: { id: 1, firstName: 'Agent', lastName: 'One' } },
-                { agentId: 2, totalBalance: new Prisma.Decimal(1000), bucket_4_7: new Prisma.Decimal(0), bucket_8_plus: new Prisma.Decimal(1000), agent: { id: 2, firstName: 'Agent', lastName: 'Two' } },
+                { agentId: 1, totalBalance: new Prisma.Decimal(500), bucket_4_7: new Prisma.Decimal(500), bucket_8_plus: new Prisma.Decimal(0), agent: { id: 1, firstName: 'Agent', lastName: 'One', tenantId: 'tenant-a' } },
+                { agentId: 2, totalBalance: new Prisma.Decimal(1000), bucket_4_7: new Prisma.Decimal(0), bucket_8_plus: new Prisma.Decimal(1000), agent: { id: 2, firstName: 'Agent', lastName: 'Two', tenantId: 'tenant-b' } },
             ];
 
             mockPrisma.agentAgingBucket.findMany.mockResolvedValue(mockBuckets);
@@ -178,8 +178,8 @@ describe('AgingService', () => {
             const result = await agingService.getOverdueAgents();
 
             expect(result).toHaveLength(2);
-            expect(result[0]).toEqual({ agentId: 1, agentName: 'Agent One', totalBalance: 500, warningAmount: 500, criticalAmount: 0 });
-            expect(result[1]).toEqual({ agentId: 2, agentName: 'Agent Two', totalBalance: 1000, warningAmount: 0, criticalAmount: 1000 });
+            expect(result[0]).toEqual({ agentId: 1, tenantId: 'tenant-a', agentName: 'Agent One', totalBalance: 500, warningAmount: 500, criticalAmount: 0 });
+            expect(result[1]).toEqual({ agentId: 2, tenantId: 'tenant-b', agentName: 'Agent Two', totalBalance: 1000, warningAmount: 0, criticalAmount: 1000 });
         });
     });
 });

--- a/backend/src/__tests__/unit/auth.test.ts
+++ b/backend/src/__tests__/unit/auth.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 
 // Mock dependencies BEFORE any other imports
 jest.mock('../../utils/jwt');
+// Token minting is centralized in mintTokens (covered by storeCore.test.ts);
+// auto-mock it so these controller-flow tests don't need its DB-backed resolution.
+jest.mock('../../utils/mintTokens');
 jest.mock('bcrypt');
 jest.mock('../../services/adminService', () => ({
   adminService: {
@@ -15,6 +18,7 @@ import { prismaMock } from '../mocks/prisma.mock';
 // Now import other dependencies
 import bcrypt from 'bcrypt';
 import { generateAccessToken, generateRefreshToken } from '../../utils/jwt';
+import { mintTokens, mintAccessToken } from '../../utils/mintTokens';
 import { login, register, refresh, logout } from '../../controllers/authController';
 import { adminService } from '../../services/adminService';
 
@@ -33,6 +37,11 @@ describe('Auth Controller', () => {
       json: jest.fn().mockReturnThis(),
     };
     mockNext = jest.fn();
+
+    // Centralized token mint — return fixed tokens so controller-flow tests
+    // don't exercise mintTokens' DB-backed active-store resolution.
+    (mintTokens as jest.Mock).mockResolvedValue({ accessToken: 'access_token', refreshToken: 'refresh_token', tenantId: 'tenant-1' });
+    (mintAccessToken as jest.Mock).mockResolvedValue({ accessToken: 'new_access_token', tenantId: 'tenant-1' });
 
     // Setup adminService mock
     (adminService.getRolePermissions as jest.Mock).mockResolvedValue({

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -3,7 +3,8 @@ import crypto from 'crypto';
 import bcrypt from 'bcrypt';
 import { AuthRequest } from '../types';
 import prisma from '../utils/prisma';
-import { generateAccessToken, generateRefreshToken, verifyRefreshToken } from '../utils/jwt';
+import { verifyRefreshToken } from '../utils/jwt';
+import { mintTokens, mintAccessToken } from '../utils/mintTokens';
 import { AppError } from '../middleware/errorHandler';
 import { adminService } from '../services/adminService';
 import { sendPasswordResetEmail } from '../services/emailService';
@@ -46,20 +47,8 @@ export const register = async (req: AuthRequest, res: Response, next: NextFuncti
       }
     });
 
-    // Generate tokens
-    const accessToken = generateAccessToken({
-      id: user.id,
-      email: user.email,
-      role: user.role,
-      tenantId: user.tenantId ?? null
-    });
-
-    const refreshToken = generateRefreshToken({
-      id: user.id,
-      email: user.email,
-      role: user.role,
-      tenantId: user.tenantId ?? null
-    });
+    // Generate tokens (fail-closed mint — never a null-tenant token)
+    const { accessToken, refreshToken } = await mintTokens(user);
 
     // Save refresh token
     await prisma.user.update({
@@ -103,19 +92,7 @@ export const login = async (req: AuthRequest, res: Response, next: NextFunction)
       throw new AppError('Invalid credentials', 401);
     }
 
-    const accessToken = generateAccessToken({
-      id: user.id,
-      email: user.email,
-      role: user.role,
-      tenantId: user.tenantId ?? null
-    });
-
-    const refreshToken = generateRefreshToken({
-      id: user.id,
-      email: user.email,
-      role: user.role,
-      tenantId: user.tenantId ?? null
-    });
+    const { accessToken, refreshToken } = await mintTokens(user);
 
     await prisma.user.update({
       where: { id: user.id },
@@ -190,12 +167,9 @@ export const refresh = async (req: AuthRequest, res: Response, next: NextFunctio
       throw new AppError('Invalid refresh token', 401);
     }
 
-    const newAccessToken = generateAccessToken({
-      id: user.id,
-      email: user.email,
-      role: user.role,
-      tenantId: user.tenantId ?? null
-    });
+    // Preserve the active store the refresh token was minted for (decoded.tenantId)
+    // rather than re-resolving to default; still fail-closed via mintAccessToken.
+    const { accessToken: newAccessToken } = await mintAccessToken(user, decoded.tenantId);
 
     res.json({
       accessToken: newAccessToken
@@ -429,19 +403,7 @@ export const registerTenant = async (req: AuthRequest, res: Response, next: Next
       return { tenant, user };
     });
 
-    const accessToken = generateAccessToken({
-      id: user.id,
-      email: user.email,
-      role: user.role,
-      tenantId: user.tenantId ?? null
-    });
-
-    const refreshToken = generateRefreshToken({
-      id: user.id,
-      email: user.email,
-      role: user.role,
-      tenantId: user.tenantId ?? null
-    });
+    const { accessToken, refreshToken } = await mintTokens(user);
 
     await prisma.user.update({
       where: { id: user.id },

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -5,6 +5,7 @@ import { AuthRequest } from '../types';
 import prisma from '../utils/prisma';
 import { verifyRefreshToken } from '../utils/jwt';
 import { mintTokens, mintAccessToken } from '../utils/mintTokens';
+import { getCurrentUser, updateCurrentUser } from '../utils/currentUser';
 import { AppError } from '../middleware/errorHandler';
 import { adminService } from '../services/adminService';
 import { sendPasswordResetEmail } from '../services/emailService';
@@ -182,10 +183,9 @@ export const refresh = async (req: AuthRequest, res: Response, next: NextFunctio
 export const logout = async (req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
   try {
     if (req.user) {
-      await prisma.user.update({
-        where: { id: req.user.id },
-        data: { refreshToken: null }
-      });
+      // Unscoped: a null-tenant owner's active store must not filter out their
+      // own row, or the refresh-token clear silently no-ops and logout is a lie.
+      await updateCurrentUser(req.user.id, { refreshToken: null });
     }
 
     res.json({ message: 'Logout successful' });
@@ -274,19 +274,18 @@ export const me = async (req: AuthRequest, res: Response, next: NextFunction): P
       throw new AppError('Unauthorized', 401);
     }
 
-    const user = await prisma.user.findUnique({
-      where: { id: req.user.id },
-      select: {
-        id: true,
-        email: true,
-        firstName: true,
-        lastName: true,
-        phoneNumber: true,
-        role: true,
-        isActive: true,
-        isAvailable: true,
-        createdAt: true
-      }
+    // Unscoped identity read: a null-tenant owner must resolve to their own row
+    // regardless of which store is active.
+    const user = await getCurrentUser(req.user.id, {
+      id: true,
+      email: true,
+      firstName: true,
+      lastName: true,
+      phoneNumber: true,
+      role: true,
+      isActive: true,
+      isAvailable: true,
+      createdAt: true
     });
 
     // Get user permissions from system config

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -2,7 +2,8 @@ import { Response, NextFunction } from 'express';
 import crypto from 'crypto';
 import bcrypt from 'bcrypt';
 import { AuthRequest } from '../types';
-import prisma from '../utils/prisma';
+import prisma, { prismaBase } from '../utils/prisma';
+import { deleteStoreData, deleteOwnerReferences } from '../services/storeDeletionService';
 import { verifyRefreshToken } from '../utils/jwt';
 import { mintTokens, mintAccessToken } from '../utils/mintTokens';
 import { getCurrentUser, updateCurrentUser } from '../utils/currentUser';
@@ -441,54 +442,34 @@ export const deleteTenantAccount = async (req: AuthRequest, res: Response, next:
     const { password } = req.body;
     if (!password) throw new AppError('Password is required to confirm deletion', 400);
 
-    // Verify password
-    const user = await prisma.user.findUnique({ where: { id: req.user.id } });
+    // Verify password. Unscoped (MAN-98): the owner is null-tenant, so the
+    // extended client would inject the active-store tenant and miss them (404).
+    const user = await prismaBase.user.findFirst({ where: { id: req.user.id, isActive: true } });
     if (!user) throw new AppError('User not found', 404);
 
     const valid = await bcrypt.compare(password, user.password);
     if (!valid) throw new AppError('Incorrect password', 401);
 
-    const tenantId = req.user.tenantId;
-    if (!tenantId) throw new AppError('No tenant associated with this account', 400);
+    // MAN-98: whole-account delete = every store this user OWNS (resolved by the
+    // ownerUserId FK, never the ambiguous active-store JWT tenant), then the owner
+    // row LAST. A legacy single-store user's own tenantId is folded in too.
+    const ownedStores = await prismaBase.tenant.findMany({
+      where: { ownerUserId: req.user.id },
+      select: { id: true },
+    });
+    const storeIds = new Set(ownedStores.map((s) => s.id));
+    if (req.user.tenantId) storeIds.add(req.user.tenantId);
+    if (storeIds.size === 0) throw new AppError('No stores associated with this account', 400);
 
-    // Delete all tenant data atomically in dependency order.
-    // Uses parameterized queries (Prisma.sql) to prevent SQL injection.
-    // Tables with RESTRICT FKs to users must be cleaned before user/tenant delete.
-    await prisma.$transaction(async (tx) => {
-      // 1. Delete records that reference users via RESTRICT FKs
-      await tx.$executeRaw`DELETE FROM notifications WHERE user_id IN (SELECT id FROM users WHERE tenant_id = ${tenantId})`;
-      await tx.$executeRaw`DELETE FROM audit_logs WHERE user_id IN (SELECT id FROM users WHERE tenant_id = ${tenantId})`;
-      await tx.$executeRaw`DELETE FROM payouts WHERE rep_id IN (SELECT id FROM users WHERE tenant_id = ${tenantId})`;
-      await tx.$executeRaw`DELETE FROM calls WHERE sales_rep_id IN (SELECT id FROM users WHERE tenant_id = ${tenantId})`;
-      await tx.$executeRaw`DELETE FROM agent_deposits WHERE agent_id IN (SELECT id FROM users WHERE tenant_id = ${tenantId})`;
-      await tx.$executeRaw`DELETE FROM agent_collections WHERE agent_id IN (SELECT id FROM users WHERE tenant_id = ${tenantId})`;
-      await tx.$executeRaw`DELETE FROM agent_aging_buckets WHERE agent_id IN (SELECT id FROM users WHERE tenant_id = ${tenantId})`;
-      await tx.$executeRaw`DELETE FROM agent_balances WHERE agent_id IN (SELECT id FROM users WHERE tenant_id = ${tenantId})`;
-      await tx.$executeRaw`DELETE FROM agent_stock WHERE agent_id IN (SELECT id FROM users WHERE tenant_id = ${tenantId})`;
-
-      // 2. NULL out user FK columns on tenant-scoped tables (these cascade from tenant delete,
-      //    but RESTRICT FKs on user columns would block the cascade)
-      await tx.$executeRaw`UPDATE orders SET created_by_id = NULL, customer_rep_id = NULL, delivery_agent_id = NULL WHERE tenant_id = ${tenantId}`;
-      await tx.$executeRaw`UPDATE deliveries SET agent_id = NULL WHERE tenant_id = ${tenantId}`;
-      await tx.$executeRaw`UPDATE inventory_shipments SET created_by_id = NULL WHERE tenant_id = ${tenantId}`;
-      await tx.$executeRaw`UPDATE inventory_transfers SET from_agent_id = NULL, to_agent_id = NULL, created_by_id = NULL WHERE tenant_id = ${tenantId}`;
-      await tx.$executeRaw`UPDATE journal_entries SET created_by = NULL, voided_by = NULL WHERE tenant_id = ${tenantId}`;
-
-      // 3. Delete remaining tenant-scoped data in dependency order
-      await tx.$executeRaw`DELETE FROM form_submissions WHERE form_id IN (SELECT id FROM checkout_forms WHERE tenant_id = ${tenantId})`;
-      await tx.$executeRaw`DELETE FROM inventory_transfers WHERE tenant_id = ${tenantId}`;
-      await tx.$executeRaw`DELETE FROM inventory_shipments WHERE tenant_id = ${tenantId}`;
-      await tx.$executeRaw`DELETE FROM account_transactions WHERE tenant_id = ${tenantId}`;
-      await tx.$executeRaw`DELETE FROM journal_entries WHERE tenant_id = ${tenantId}`;
-      await tx.$executeRaw`DELETE FROM system_config WHERE tenant_id = ${tenantId}`;
-
-      // 4. Delete tenant — CASCADE handles remaining tenant_id FKs (orders, customers, etc.)
-      //    Using raw SQL to bypass Prisma soft-delete extensions
-      // MAN-87: release the owner ref first — the RESTRICT FK on
-      // tenants.owner_user_id would otherwise block deleting the owner user.
-      await tx.$executeRaw`UPDATE tenants SET owner_user_id = NULL WHERE id = ${tenantId}`;
-      await tx.$executeRaw`DELETE FROM users WHERE tenant_id = ${tenantId}`;
-      await tx.$executeRaw`DELETE FROM tenants WHERE id = ${tenantId}`;
+    // Delete all owned stores atomically, then the owner. Raw parameterized SQL
+    // in dependency order; RESTRICT FKs to users are cleaned before user delete.
+    // prismaBase: the deletes bypass extensions and the helper takes a plain tx.
+    await prismaBase.$transaction(async (tx) => {
+      for (const sid of storeIds) {
+        await deleteStoreData(tx, sid);
+      }
+      // Owner row last — deleteStoreData never removes the (null-tenant) owner.
+      await deleteOwnerReferences(tx, req.user!.id);
     });
 
     res.json({ message: 'Account and all associated data have been permanently deleted' });

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -206,12 +206,11 @@ export const forgotPassword = async (req: AuthRequest, res: Response, next: Next
         const hashedToken = crypto.createHash('sha256').update(rawToken).digest('hex');
         const expires = new Date(Date.now() + 15 * 60 * 1000);
 
-        await prisma.user.update({
-          where: { id: user.id },
-          data: {
-            passwordResetToken: hashedToken,
-            passwordResetExpires: expires,
-          },
+        // Unscoped write (MAN-94 owner carve-out): a null-tenant owner's own row
+        // must not be filtered out by an ambient active-store scope.
+        await updateCurrentUser(user.id, {
+          passwordResetToken: hashedToken,
+          passwordResetExpires: expires,
         });
 
         const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5173';
@@ -252,14 +251,13 @@ export const resetPassword = async (req: AuthRequest, res: Response, next: NextF
 
     const hashedPassword = await bcrypt.hash(password, 10);
 
-    await prisma.user.update({
-      where: { id: user.id },
-      data: {
-        password: hashedPassword,
-        passwordResetToken: null,
-        passwordResetExpires: null,
-        refreshToken: null,
-      },
+    // Unscoped write (MAN-94 owner carve-out): reset must succeed for a
+    // null-tenant owner, and it also invalidates their session (refreshToken).
+    await updateCurrentUser(user.id, {
+      password: hashedPassword,
+      passwordResetToken: null,
+      passwordResetExpires: null,
+      refreshToken: null,
     });
 
     res.json({ message: 'Password reset successful. Please log in with your new password.' });

--- a/backend/src/controllers/financialController.ts
+++ b/backend/src/controllers/financialController.ts
@@ -398,7 +398,10 @@ export const backfillMissingCollections = async (_req: AuthRequest, res: Respons
         AND o.deleted_at IS NULL
         AND o.delivery_agent_id IS NOT NULL
         AND o.tenant_id = ${tenantId}
-        AND o.id NOT IN (SELECT order_id FROM agent_collections)
+        -- MAN-99: correlate to the tenant-scoped order o (agent_collections is not
+        -- in TENANT_SCOPED_MODELS, so a bare subquery is unscoped); NOT EXISTS on
+        -- ac.order_id = o.id can only match this tenant's own collections.
+        AND NOT EXISTS (SELECT 1 FROM agent_collections ac WHERE ac.order_id = o.id)
       ORDER BY o.created_at ASC
     `;
 

--- a/backend/src/controllers/onboardingController.ts
+++ b/backend/src/controllers/onboardingController.ts
@@ -1,6 +1,6 @@
 import { Response, NextFunction } from 'express';
 import { AuthRequest } from '../types';
-import prisma from '../utils/prisma';
+import prisma, { prismaBase } from '../utils/prisma';
 import { AppError } from '../middleware/errorHandler';
 
 export const setupOnboarding = async (req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
@@ -13,17 +13,27 @@ export const setupOnboarding = async (req: AuthRequest, res: Response, next: Nex
     if (!tenantId) {
       tenantId = existingUser?.tenantId ?? null;
 
-      // Legacy user with no tenant — create one automatically
+      // Legacy user with no tenant — create one automatically.
+      // MAN-94: a multi-store OWNER is legitimately null-tenant (they provision
+      // stores via the platform console, not onboarding) and always has at least
+      // their default StoreMembership. Only a membership-less legacy user still
+      // auto-creates here — never mint a stray "company-N" tenant for an owner.
       if (!tenantId && existingUser) {
-        const slug = `company-${req.user.id}`;
-        // MAN-87: set the owner inline — unlike the register flow, the owning
-        // user already exists here, so the circular FK doesn't force a
-        // separate link step after create.
-        const tenant = await prisma.tenant.create({
-          data: { name: `${existingUser.firstName}'s Company`, slug, ownerUserId: req.user.id }
+        const membership = await prismaBase.storeMembership.findFirst({
+          where: { userId: req.user.id },
+          select: { id: true },
         });
-        await prisma.user.update({ where: { id: req.user.id }, data: { tenantId: tenant.id } });
-        tenantId = tenant.id;
+        if (!membership) {
+          const slug = `company-${req.user.id}`;
+          // MAN-87: set the owner inline — unlike the register flow, the owning
+          // user already exists here, so the circular FK doesn't force a
+          // separate link step after create.
+          const tenant = await prisma.tenant.create({
+            data: { name: `${existingUser.firstName}'s Company`, slug, ownerUserId: req.user.id }
+          });
+          await prisma.user.update({ where: { id: req.user.id }, data: { tenantId: tenant.id } });
+          tenantId = tenant.id;
+        }
       }
     }
     if (!tenantId) throw new AppError('User has no tenant assigned', 400);

--- a/backend/src/controllers/storeController.ts
+++ b/backend/src/controllers/storeController.ts
@@ -1,8 +1,10 @@
 import { Response, NextFunction } from 'express';
+import bcrypt from 'bcrypt';
 import { AuthRequest } from '../types';
 import { prismaBase } from '../utils/prisma';
 import { AppError } from '../middleware/errorHandler';
 import { mintTokens } from '../utils/mintTokens';
+import { deleteStoreData } from '../services/storeDeletionService';
 
 /**
  * GET /api/stores — list the stores the caller owns (their StoreMembership rows).
@@ -82,6 +84,49 @@ export const switchStore = async (req: AuthRequest, res: Response, next: NextFun
     });
 
     res.json({ accessToken, refreshToken, activeTenantId: tenantId });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * DELETE /api/stores/:id — delete-THIS-store. Owner-scoped (Tenant.ownerUserId),
+ * requires the store name typed back + the owner's password, and refuses to
+ * delete the owner's only store. Removes just this store's data; the owner and
+ * their other stores survive. Whole-account deletion is DELETE /api/auth/account.
+ */
+export const deleteStore = async (req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    if (!req.user) throw new AppError('Unauthorized', 401);
+    const storeId = req.params.id;
+    const { password, confirmName } = req.body ?? {};
+
+    const tenant = await prismaBase.tenant.findUnique({
+      where: { id: storeId },
+      select: { ownerUserId: true, name: true },
+    });
+    if (!tenant) throw new AppError('Store not found', 404);
+    if (tenant.ownerUserId !== req.user.id) {
+      throw new AppError('Only the store owner can delete this store', 403);
+    }
+    if (confirmName !== tenant.name) {
+      throw new AppError('Store name confirmation does not match', 400);
+    }
+
+    const user = await prismaBase.user.findFirst({ where: { id: req.user.id, isActive: true }, select: { password: true } });
+    if (!user) throw new AppError('User not found', 404);
+    const valid = await bcrypt.compare(password ?? '', user.password);
+    if (!valid) throw new AppError('Incorrect password', 401);
+
+    // Never leave an owner with zero stores — that would strand them.
+    const owned = await prismaBase.tenant.count({ where: { ownerUserId: req.user.id } });
+    if (owned <= 1) throw new AppError('You cannot delete your only store', 400);
+
+    await prismaBase.$transaction(async (tx) => {
+      await deleteStoreData(tx, storeId);
+    });
+
+    res.json({ message: 'Store and its data have been permanently deleted' });
   } catch (error) {
     next(error);
   }

--- a/backend/src/controllers/storeController.ts
+++ b/backend/src/controllers/storeController.ts
@@ -1,0 +1,88 @@
+import { Response, NextFunction } from 'express';
+import { AuthRequest } from '../types';
+import { prismaBase } from '../utils/prisma';
+import { AppError } from '../middleware/errorHandler';
+import { mintTokens } from '../utils/mintTokens';
+
+/**
+ * GET /api/stores — list the stores the caller owns (their StoreMembership rows).
+ * Not behind requireResolvedTenant: an owner sitting on a null/pending active
+ * store must still be able to see and switch stores. StoreMembership is not
+ * tenant-scoped; read through prismaBase to stay off the ambient scope.
+ */
+export const getStores = async (req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    if (!req.user) throw new AppError('Unauthorized', 401);
+
+    const memberships = await prismaBase.storeMembership.findMany({
+      where: { userId: req.user.id },
+      select: {
+        tenantId: true,
+        role: true,
+        isDefault: true,
+        tenant: { select: { name: true, slug: true, subscriptionStatus: true } },
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    const activeTenantId = req.user.tenantId ?? null;
+
+    res.json({
+      stores: memberships.map((m) => ({
+        tenantId: m.tenantId,
+        name: m.tenant.name,
+        slug: m.tenant.slug,
+        subscriptionStatus: m.tenant.subscriptionStatus,
+        role: m.role,
+        isDefault: m.isDefault,
+        isActive: m.tenantId === activeTenantId,
+      })),
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * POST /api/stores/switch { tenantId } — re-issue a token scoped to a store the
+ * caller owns. 403 if the target is not one of their memberships. Single-active-
+ * session: the new refresh token overwrites the old one, so the previous tab's
+ * refresh token stops working (registry #5, v1 decision).
+ */
+export const switchStore = async (req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    if (!req.user) throw new AppError('Unauthorized', 401);
+
+    const { tenantId } = req.body ?? {};
+    if (!tenantId || typeof tenantId !== 'string') {
+      throw new AppError('tenantId is required', 400);
+    }
+
+    const membership = await prismaBase.storeMembership.findFirst({
+      where: { userId: req.user.id, tenantId },
+      select: { id: true },
+    });
+    if (!membership) {
+      throw new AppError('Not a member of that store', 403, 'NOT_A_MEMBER');
+    }
+
+    const user = await prismaBase.user.findFirst({
+      where: { id: req.user.id, isActive: true },
+      select: { id: true, email: true, role: true, tenantId: true },
+    });
+    if (!user) throw new AppError('User not found', 404);
+
+    // Explicit target = the store being switched to; mintTokens validates it
+    // resolves (it does — it is a confirmed membership) and fails closed otherwise.
+    const { accessToken, refreshToken } = await mintTokens(user, tenantId);
+
+    await prismaBase.user.update({
+      where: { id: user.id },
+      data: { refreshToken },
+    });
+
+    res.json({ accessToken, refreshToken, activeTenantId: tenantId });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/middleware/platformAuth.ts
+++ b/backend/src/middleware/platformAuth.ts
@@ -1,7 +1,7 @@
 import { Response, NextFunction } from 'express';
 import { AuthRequest } from '../types';
 import { tenantStorage } from '../utils/tenantContext';
-import prisma from '../utils/prisma';
+import { prismaBase } from '../utils/prisma';
 
 /**
  * Requires isPlatformAdmin flag on the user and nullifies tenant context
@@ -15,8 +15,14 @@ export const requirePlatformAdmin = async (req: AuthRequest, res: Response, next
     return;
   }
 
-  const user = await prisma.user.findUnique({
-    where: { id: req.user.id },
+  // Resolve platform-admin identity through the UNSCOPED client, BEFORE nullifying
+  // tenant context. An owner in platform mode legitimately holds a null (or other
+  // store's) active tenant; the extended client would inject that tenant into this
+  // lookup (User is tenant-scoped) and fail to find the owner — a 403 lockout that
+  // also traps brand-new zero-store owners out of the provisioning console. This is
+  // the zero-store bootstrap: platform-admin auth needs no resolved store.
+  const user = await prismaBase.user.findFirst({
+    where: { id: req.user.id, isActive: true },
     select: { isPlatformAdmin: true },
   });
 

--- a/backend/src/routes/storeRoutes.ts
+++ b/backend/src/routes/storeRoutes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { authenticate } from '../middleware/auth';
-import { getStores, switchStore } from '../controllers/storeController';
+import { getStores, switchStore, deleteStore } from '../controllers/storeController';
 
 const router = Router();
 
@@ -11,5 +11,6 @@ router.use(authenticate);
 
 router.get('/', getStores);
 router.post('/switch', switchStore);
+router.delete('/:id', deleteStore);
 
 export default router;

--- a/backend/src/routes/storeRoutes.ts
+++ b/backend/src/routes/storeRoutes.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import { authenticate } from '../middleware/auth';
+import { getStores, switchStore } from '../controllers/storeController';
+
+const router = Router();
+
+// Authenticated but NOT requireResolvedTenant: an owner with a null/pending
+// active store must still list and switch stores. These endpoints touch only
+// StoreMembership (not tenant-scoped), never tenant-scoped data.
+router.use(authenticate);
+
+router.get('/', getStores);
+router.post('/switch', switchStore);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -46,6 +46,7 @@ import { derivePlatformOrigin } from './utils/corsOrigins';
 // Routes
 import authRoutes from './routes/authRoutes';
 import userRoutes from './routes/userRoutes';
+import storeRoutes from './routes/storeRoutes';
 import customerRoutes from './routes/customerRoutes';
 import productRoutes from './routes/productRoutes';
 import orderRoutes from './routes/orderRoutes';
@@ -215,6 +216,7 @@ app.use('/', healthRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/admin', apiLimiter, adminRoutes);
 app.use('/api/users', apiLimiter, userRoutes);
+app.use('/api/stores', apiLimiter, storeRoutes);
 app.use('/api/customers', apiLimiter, customerRoutes);
 app.use('/api/products', apiLimiter, productRoutes);
 app.use('/api/orders', apiLimiter, orderRoutes);

--- a/backend/src/services/agingService.ts
+++ b/backend/src/services/agingService.ts
@@ -290,7 +290,7 @@ export class AgingService {
    * Get agents with overdue collections (4-7 day or 8+ day buckets)
    * Used by the notification job to alert admins
    */
-  async getOverdueAgents(): Promise<{ agentId: number; agentName: string; totalBalance: number; warningAmount: number; criticalAmount: number }[]> {
+  async getOverdueAgents(): Promise<{ agentId: number; tenantId: string | null; agentName: string; totalBalance: number; warningAmount: number; criticalAmount: number }[]> {
     const overdueBuckets = await (prisma as any).agentAgingBucket.findMany({
       where: {
         OR: [
@@ -300,13 +300,16 @@ export class AgingService {
       },
       include: {
         agent: {
-          select: { id: true, firstName: true, lastName: true }
+          // tenantId lets the notifier group overdue agents by store and page
+          // that store's owner, not every admin across every tenant (MAN-95).
+          select: { id: true, firstName: true, lastName: true, tenantId: true }
         }
       }
     });
 
     return overdueBuckets.map((bucket: any) => ({
       agentId: bucket.agentId,
+      tenantId: bucket.agent.tenantId ?? null,
       agentName: `${bucket.agent.firstName} ${bucket.agent.lastName}`,
       totalBalance: parseFloat(bucket.totalBalance.toString()),
       warningAmount: parseFloat(bucket.bucket_4_7.toString()),

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -1,4 +1,4 @@
-import prisma from '../utils/prisma';
+import prisma, { prismaBase } from '../utils/prisma';
 import { getSocketInstance } from '../utils/socketInstance';
 import { emitNotification } from '../sockets';
 
@@ -72,33 +72,41 @@ export async function notifyDeliveryScheduled(
 }
 
 export async function notifyAdminsOverdueCollections(
-  agents: { agentId: number; agentName: string; totalBalance: number; warningAmount: number; criticalAmount: number }[]
+  agents: { agentId: number; tenantId: string | null; agentName: string; totalBalance: number; warningAmount: number; criticalAmount: number }[]
 ) {
   if (agents.length === 0) return;
 
-  // Find all admin and super_admin users
-  // TODO(MAN-88 guard lane): this query is not tenant-scoped — it notifies admins
-  // across every tenant. Scope to the store owner (Tenant.ownerUserId) once the
-  // caller threads a tenantId; deferred to the isolation-guard lane because it
-  // needs a signature + caller change, not just an owner-read swap.
-  const admins = await prisma.user.findMany({
-    where: { role: { in: ['admin', 'super_admin'] }, isActive: true },
-    select: { id: true }
-  });
+  // MAN-95: this cron runs cross-tenant, so notifying every admin leaked each
+  // store's collections to every other store's admins. Group the overdue agents
+  // by their store, then page THAT store's owner resolved by direct FK
+  // (Tenant.ownerUserId) — not by a (tenantId, role) scan. prismaBase because a
+  // system cron has no tenant context and we resolve each owner explicitly.
+  const byTenant = new Map<string, typeof agents>();
+  for (const a of agents) {
+    if (!a.tenantId) continue; // orphan agent with no store — nobody to notify
+    const list = byTenant.get(a.tenantId) ?? [];
+    list.push(a);
+    byTenant.set(a.tenantId, list);
+  }
 
-  const agentSummary = agents
-    .map(a => `${a.agentName}: GHS ${a.totalBalance.toFixed(2)} (${a.criticalAmount > 0 ? '8+ days' : '4-7 days'})`)
-    .join(', ');
+  for (const [tenantId, tenantAgents] of byTenant) {
+    const tenant = await prismaBase.tenant.findUnique({
+      where: { id: tenantId },
+      select: { ownerUserId: true },
+    });
+    if (!tenant?.ownerUserId) continue; // store has no owner yet — skip
 
-  const totalOverdue = agents.reduce((sum, a) => sum + a.totalBalance, 0);
+    const agentSummary = tenantAgents
+      .map(a => `${a.agentName}: GHS ${a.totalBalance.toFixed(2)} (${a.criticalAmount > 0 ? '8+ days' : '4-7 days'})`)
+      .join(', ');
+    const totalOverdue = tenantAgents.reduce((sum, a) => sum + a.totalBalance, 0);
 
-  for (const admin of admins) {
     await createNotification(
-      admin.id.toString(),
+      tenant.ownerUserId.toString(),
       'overdue_collections',
       'Overdue Agent Collections',
-      `${agents.length} agent(s) have overdue collections totaling GHS ${totalOverdue.toFixed(2)}: ${agentSummary}`,
-      { agents, totalOverdue }
+      `${tenantAgents.length} agent(s) have overdue collections totaling GHS ${totalOverdue.toFixed(2)}: ${agentSummary}`,
+      { agents: tenantAgents, totalOverdue }
     );
   }
 }

--- a/backend/src/services/storeDeletionService.ts
+++ b/backend/src/services/storeDeletionService.ts
@@ -1,0 +1,62 @@
+import { Prisma } from '@prisma/client';
+
+/**
+ * Permanently delete one store (tenant) and all of its tenant-scoped data inside
+ * an existing transaction. Raw parameterized SQL in dependency order, bypassing
+ * the Prisma soft-delete/tenant extensions.
+ *
+ * IMPORTANT (multi-store): this deletes STAFF users (users.tenant_id = tenantId)
+ * but NOT the owner — a multi-store owner's user.tenant_id is null, so they
+ * survive a single-store delete and keep their other stores. delete-account
+ * removes the owner separately, last (see deleteOwnerReferences).
+ */
+export async function deleteStoreData(tx: Prisma.TransactionClient, tenantId: string): Promise<void> {
+  // 1. Delete records that reference users via RESTRICT FKs
+  await tx.$executeRaw`DELETE FROM notifications WHERE user_id IN (SELECT id FROM users WHERE tenant_id = ${tenantId})`;
+  await tx.$executeRaw`DELETE FROM audit_logs WHERE user_id IN (SELECT id FROM users WHERE tenant_id = ${tenantId})`;
+  await tx.$executeRaw`DELETE FROM payouts WHERE rep_id IN (SELECT id FROM users WHERE tenant_id = ${tenantId})`;
+  await tx.$executeRaw`DELETE FROM calls WHERE sales_rep_id IN (SELECT id FROM users WHERE tenant_id = ${tenantId})`;
+  await tx.$executeRaw`DELETE FROM agent_deposits WHERE agent_id IN (SELECT id FROM users WHERE tenant_id = ${tenantId})`;
+  await tx.$executeRaw`DELETE FROM agent_collections WHERE agent_id IN (SELECT id FROM users WHERE tenant_id = ${tenantId})`;
+  await tx.$executeRaw`DELETE FROM agent_aging_buckets WHERE agent_id IN (SELECT id FROM users WHERE tenant_id = ${tenantId})`;
+  await tx.$executeRaw`DELETE FROM agent_balances WHERE agent_id IN (SELECT id FROM users WHERE tenant_id = ${tenantId})`;
+  await tx.$executeRaw`DELETE FROM agent_stock WHERE agent_id IN (SELECT id FROM users WHERE tenant_id = ${tenantId})`;
+
+  // 2. NULL out user FK columns on tenant-scoped tables (RESTRICT FKs on user
+  //    columns would otherwise block the tenant cascade)
+  await tx.$executeRaw`UPDATE orders SET created_by_id = NULL, customer_rep_id = NULL, delivery_agent_id = NULL WHERE tenant_id = ${tenantId}`;
+  await tx.$executeRaw`UPDATE deliveries SET agent_id = NULL WHERE tenant_id = ${tenantId}`;
+  await tx.$executeRaw`UPDATE inventory_shipments SET created_by_id = NULL WHERE tenant_id = ${tenantId}`;
+  await tx.$executeRaw`UPDATE inventory_transfers SET from_agent_id = NULL, to_agent_id = NULL, created_by_id = NULL WHERE tenant_id = ${tenantId}`;
+  await tx.$executeRaw`UPDATE journal_entries SET created_by = NULL, voided_by = NULL WHERE tenant_id = ${tenantId}`;
+
+  // 3. Delete remaining tenant-scoped data in dependency order
+  await tx.$executeRaw`DELETE FROM form_submissions WHERE form_id IN (SELECT id FROM checkout_forms WHERE tenant_id = ${tenantId})`;
+  await tx.$executeRaw`DELETE FROM inventory_transfers WHERE tenant_id = ${tenantId}`;
+  await tx.$executeRaw`DELETE FROM inventory_shipments WHERE tenant_id = ${tenantId}`;
+  await tx.$executeRaw`DELETE FROM account_transactions WHERE tenant_id = ${tenantId}`;
+  await tx.$executeRaw`DELETE FROM journal_entries WHERE tenant_id = ${tenantId}`;
+  await tx.$executeRaw`DELETE FROM system_config WHERE tenant_id = ${tenantId}`;
+
+  // 4. Release the owner ref (RESTRICT), delete staff users, then the tenant.
+  //    Deleting the tenant CASCADEs remaining tenant_id FKs (orders, customers,
+  //    store_memberships, etc.).
+  await tx.$executeRaw`UPDATE tenants SET owner_user_id = NULL WHERE id = ${tenantId}`;
+  await tx.$executeRaw`DELETE FROM users WHERE tenant_id = ${tenantId}`;
+  await tx.$executeRaw`DELETE FROM tenants WHERE id = ${tenantId}`;
+}
+
+/**
+ * Delete the owner's own user row LAST, after all their stores are gone. Clears
+ * the RESTRICT-referencing rows the owner may hold (notifications, audit logs,
+ * memberships) first. Owners are not agents/reps, but we clear those refs too so
+ * the delete can never be blocked.
+ */
+export async function deleteOwnerReferences(tx: Prisma.TransactionClient, ownerId: number): Promise<void> {
+  await tx.$executeRaw`DELETE FROM notifications WHERE user_id = ${ownerId}`;
+  await tx.$executeRaw`DELETE FROM audit_logs WHERE user_id = ${ownerId}`;
+  await tx.$executeRaw`DELETE FROM payouts WHERE rep_id = ${ownerId}`;
+  await tx.$executeRaw`DELETE FROM calls WHERE sales_rep_id = ${ownerId}`;
+  await tx.$executeRaw`DELETE FROM store_memberships WHERE user_id = ${ownerId}`;
+  await tx.$executeRaw`DELETE FROM users WHERE id = ${ownerId}`;
+}

--- a/backend/src/utils/currentUser.ts
+++ b/backend/src/utils/currentUser.ts
@@ -1,0 +1,19 @@
+import { Prisma } from '@prisma/client';
+import { prismaBase } from './prisma';
+
+/**
+ * Identity carve-out for the authenticated user's OWN row.
+ *
+ * Owners are null-tenant once multi-store is live, so the extended client would
+ * inject the active-store tenant into these queries (User is tenant-scoped) and
+ * either miss the owner (reads return nothing) or silently no-op (writes match
+ * zero rows). Both go through prismaBase (unscoped) with an explicit id
+ * predicate, so identity resolves the same for owners and staff.
+ */
+export async function getCurrentUser(userId: number, select?: Prisma.UserSelect) {
+  return prismaBase.user.findFirst({ where: { id: userId, isActive: true }, select });
+}
+
+export async function updateCurrentUser(userId: number, data: Prisma.UserUpdateInput) {
+  return prismaBase.user.update({ where: { id: userId }, data });
+}

--- a/backend/src/utils/mintTokens.ts
+++ b/backend/src/utils/mintTokens.ts
@@ -1,0 +1,83 @@
+import { UserRole } from '@prisma/client';
+import { generateAccessToken, generateRefreshToken } from './jwt';
+import { prismaBase } from './prisma';
+import logger from './logger';
+import { AppError } from '../middleware/errorHandler';
+
+/** Minimal user shape needed to mint a token. */
+export interface MintableUser {
+  id: number;
+  email: string;
+  role: UserRole;
+  tenantId?: string | null;
+}
+
+/**
+ * Resolve the "active store" for a token mint:
+ *   explicit target (store switch / refresh preserving current store) wins,
+ *   else the user's own tenantId (staff — behavior unchanged),
+ *   else their default StoreMembership (owners, whose User.tenantId is nulled
+ *   once the multi-store path is live).
+ * Returns null only when NONE resolves. Read through prismaBase (StoreMembership
+ * is not tenant-scoped, but the auth/identity layer stays off the ambient scope
+ * on principle). Callers MUST fail closed on null — see resolveOrThrow.
+ */
+export async function resolveActiveTenantId(
+  user: MintableUser,
+  explicitTenantId?: string | null,
+): Promise<string | null> {
+  if (explicitTenantId) return explicitTenantId;
+  if (user.tenantId) return user.tenantId;
+  const def = await prismaBase.storeMembership.findFirst({
+    where: { userId: user.id, isDefault: true },
+    select: { tenantId: true },
+  });
+  return def?.tenantId ?? null;
+}
+
+async function resolveOrThrow(user: MintableUser, explicitTenantId?: string | null): Promise<string> {
+  const tenantId = await resolveActiveTenantId(user, explicitTenantId);
+  if (!tenantId) {
+    // The fail-open crux: a null-tenant token makes auth.ts:162 run the request
+    // UNSCOPED (the Prisma extension injects no filter on null context). Refuse
+    // to mint and page on-call via this structured tripwire instead.
+    logger.error(
+      `[auth.null_tenant_context] mintTokens could not resolve an active store for user ${user.id} (${user.email}); refusing to mint a null-tenant token`,
+    );
+    throw new AppError('No active store resolved', 403, 'TENANT_UNRESOLVED');
+  }
+  return tenantId;
+}
+
+/**
+ * Single fail-closed access+refresh mint surface. Replaces the scattered
+ * `tenantId: user.tenantId ?? null` sign calls (register/login/onboarding) so
+ * there is ONE audited place a null-tenant token could ever be minted — and it
+ * never is.
+ */
+export async function mintTokens(
+  user: MintableUser,
+  explicitTenantId?: string | null,
+): Promise<{ accessToken: string; refreshToken: string; tenantId: string }> {
+  const tenantId = await resolveOrThrow(user, explicitTenantId);
+  const payload = { id: user.id, email: user.email, role: user.role, tenantId };
+  return {
+    accessToken: generateAccessToken(payload),
+    refreshToken: generateRefreshToken(payload),
+    tenantId,
+  };
+}
+
+/**
+ * Access-token-only mint (refresh path — no refresh-token rotation). Same
+ * fail-closed resolution; pass the current token's active store as
+ * explicitTenantId so a refresh keeps the user on the same store.
+ */
+export async function mintAccessToken(
+  user: MintableUser,
+  explicitTenantId?: string | null,
+): Promise<{ accessToken: string; tenantId: string }> {
+  const tenantId = await resolveOrThrow(user, explicitTenantId);
+  const payload = { id: user.id, email: user.email, role: user.role, tenantId };
+  return { accessToken: generateAccessToken(payload), tenantId };
+}


### PR DESCRIPTION
## Owner-plumbing lane — multi-store-per-login

Stacked on the Foundation lane (**#292**, base `feature/multi-store-per-login`). GitHub retargets this to `develop` when #292 merges. Diff here is exactly the 10 Owner-plumbing commits.

Once multi-store is live an **owner's `User.tenantId` is null** (they provision/switch stores; they are not staff of any one store). The fail-open Prisma extension injects no filter on null tenant, so every identity/owner read or write that used the extended client would either miss the owner or run unscoped. This lane routes each of those through the **unscoped `prismaBase`** client with an explicit `id`/`ownerUserId`/membership predicate, and centralizes token minting so a null-tenant token can never be issued.

### What's in it
| Issue | Change |
|---|---|
| **MAN-108** | Central fail-closed `mintTokens`/`mintAccessToken` (throws 403 `TENANT_UNRESOLVED` on null); new `GET /api/stores`, `POST /api/stores/switch` |
| **MAN-92** | `platformAuth` resolves admin identity via `prismaBase` **before** nullifying tenant context → zero-store owner bootstrap (no 403 lockout) |
| **MAN-93** | `me`/`logout` identity carve-out (`currentUser.ts`); refresh already routes through `mintAccessToken` |
| **MAN-94** | Owner write-path carve-out; gate onboarding auto-create so an owner never mints a stray `company-N` tenant |
| **MAN-95** | Overdue-collections notifier groups by store and pages that store's **owner** (fixes a cross-tenant leak); unit + integration tests |
| **MAN-96 / MAN-97** | Schema docs: zero-User-row owner invariant; single-active-session (v1) on `refreshToken` |
| **MAN-98** | Split deletion: `DELETE /api/stores/:id` (this store, owner+other stores survive) vs delete-account (all owned stores, owner last); `storeDeletionService.ts` |
| **MAN-99** | Raw-query audit on models absent from `TENANT_SCOPED_MODELS`; `backfillMissingCollections` rewritten to a correlated `NOT EXISTS` |

### Security — /cso daily, 0 Critical / 0 High
Reviewed `feature/multi-store-per-login..HEAD`, focused on unscoped-`prismaBase` cross-tenant risk. Verified by code-tracing:
- **No null-tenant token can be minted:** `generateAccessToken/RefreshToken` are called only inside `mintTokens.ts`; every path routes through `resolveOrThrow`. Zero bypass sites.
- **`platformAuth` authz intact + tightened:** still gates `isPlatformAdmin`; `isActive:true` now rejects deactivated admins.
- **No IDOR:** `switch`/`get`/`delete` stores are self-scoped to `req.user.id` (membership or `ownerUserId`).
- **`storeDeletionService` raw SQL** fully parameterized and tenant/owner-scoped per statement.
- One informational note (refresh trusts the signed+DB-matched `explicitTenantId`; standard JWT staleness, below the 8/10 gate).

### Tests
Full backend suite green (pre-push gate passed): 1090 passed. New acceptance tests per issue: `storeCore`, `platformAuth`, `authIdentity`, `onboardingGate`, `notifyOverdueOwner`, `storeDeletion`, `requireResolvedTenant`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)