### PR TITLE
Multi-Store: Billing lane (MAN-89/90/91) — per-store subscriptions

### DIFF
--- a/backend/prisma/migrations/20260707120000_add_tenant_billing_email/migration.sql
+++ b/backend/prisma/migrations/20260707120000_add_tenant_billing_email/migration.sql
@@ -1,0 +1,5 @@
+-- MAN-89: per-store billing email (plus-addressed alias of the owner's email,
+-- e.g. owner+store-acme@x.com) so Paystack keys a DISTINCT customer per store.
+-- Additive, nullable, no backfill — existing tenants keep NULL and bill to the
+-- owner's plain email. Reverse = DROP COLUMN "billing_email".
+ALTER TABLE "tenants" ADD COLUMN "billing_email" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -25,6 +25,12 @@ model Tenant {
   subscriptionRenewsAt      DateTime? @map("subscription_renews_at")
   paymentFailedAt           DateTime? @map("payment_failed_at")
   paystackCardLast4         String?   @map("paystack_card_last4")
+  // MAN-89: per-store billing email (plus-addressed alias of the owner's email,
+  // e.g. owner+store-acme@x.com). Paystack keys a DISTINCT customer per store off
+  // this, so one owner's several stores never collide on one Paystack customer —
+  // which is what makes webhook routing by customer unambiguous. Null for tenants
+  // created before multi-store (they bill to the owner's plain email).
+  billingEmail              String?   @map("billing_email")
   freeAccessExpiresAt       DateTime? @map("free_access_expires_at")
   rateLimitEnabled          Boolean   @default(false) @map("rate_limit_enabled")
   rateLimitConfig           Json?     @map("rate_limit_config")

--- a/backend/src/__tests__/integration/storeProvision.test.ts
+++ b/backend/src/__tests__/integration/storeProvision.test.ts
@@ -153,4 +153,14 @@ describe('POST /api/stores', () => {
       .send({ planName: 'growth' });
     expect(res.status).toBe(400);
   });
+
+  it('rejects a non-super_admin caller (403) — provisioning is owner-only', async () => {
+    const staffToken = generateAccessToken({ id: ownerId, email: OWNER_EMAIL, role: 'sales_rep', tenantId: existingStoreId });
+    const res = await request(app)
+      .post('/api/stores')
+      .set('Authorization', `Bearer ${staffToken}`)
+      .send({ name: 'Sneaky Shop', planName: 'growth' });
+    expect(res.status).toBe(403);
+    expect(mockInit).not.toHaveBeenCalled();
+  });
 });

--- a/backend/src/__tests__/integration/storeProvision.test.ts
+++ b/backend/src/__tests__/integration/storeProvision.test.ts
@@ -1,0 +1,156 @@
+/**
+ * MAN-89: POST /api/stores — pay-before-materialize provisioning.
+ *
+ * Creating a 2nd store lands a `pending` Tenant + owner StoreMembership + a
+ * per-store billing email, and kicks off a Paystack subscription with that
+ * distinct email (so Paystack mints a DISTINCT customer per store). The store is
+ * never marked active here — charge.success does that via the webhook.
+ */
+import { jest, describe, it, expect, beforeAll, beforeEach, afterAll } from '@jest/globals';
+import request from 'supertest';
+
+const mockInit = jest.fn();
+jest.mock('../../services/platformPaystackService', () => ({
+  isPlatformBillingConfigured: jest.fn(() => true),
+  platformPaystackService: {
+    initializeSubscriptionTransaction: (...a: any[]) => (mockInit as any)(...a),
+  },
+}));
+jest.mock('../../utils/socketInstance', () => ({
+  setSocketInstance: jest.fn(),
+  getSocketInstance: jest.fn(() => ({ to: jest.fn(() => ({ emit: jest.fn() })), emit: jest.fn() })),
+  hasSocketInstance: jest.fn(() => true),
+}));
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import app from '../../server';
+import { prismaBase } from '../../utils/prisma';
+import { generateAccessToken } from '../../utils/jwt';
+
+const SUFFIX = Date.now();
+const OWNER_EMAIL = `prov-owner-${SUFFIX}@shop.com`;
+
+let ownerId: number;
+let existingStoreId: string;
+let ownerToken: string;
+const createdTenantIds: string[] = [];
+
+// resetMocks:true wipes implementations before every test, so (re)set the
+// resolved value here rather than once in beforeAll.
+beforeEach(() => {
+  mockInit.mockResolvedValue({
+    authorization_url: 'https://checkout.paystack.com/xyz',
+    access_code: 'AC_test',
+    reference: 'ref_test_123',
+  });
+});
+
+beforeAll(async () => {
+  await prismaBase.plan.upsert({
+    where: { name: 'growth' },
+    update: { paystackPlanCode: 'PLN_growth_test', priceNGN: 15000, isActive: true },
+    create: {
+      name: 'growth', displayName: 'Growth', priceGHS: 200, priceNGN: 15000,
+      paystackPlanCode: 'PLN_growth_test', features: {}, isActive: true,
+    },
+  });
+
+  const store = await prismaBase.tenant.create({
+    data: { name: `Existing ${SUFFIX}`, slug: `existing-${SUFFIX}`, subscriptionStatus: 'active' },
+  });
+  existingStoreId = store.id;
+  createdTenantIds.push(existingStoreId);
+
+  const owner = await prismaBase.user.create({
+    data: { email: OWNER_EMAIL, password: 'x', role: 'super_admin', firstName: 'Prov', lastName: 'Owner', tenantId: existingStoreId },
+  });
+  ownerId = owner.id;
+  await prismaBase.tenant.update({ where: { id: existingStoreId }, data: { ownerUserId: ownerId } });
+  await prismaBase.storeMembership.create({
+    data: { userId: ownerId, tenantId: existingStoreId, role: 'super_admin', isDefault: true },
+  });
+
+  ownerToken = generateAccessToken({ id: ownerId, email: OWNER_EMAIL, role: 'super_admin', tenantId: existingStoreId });
+});
+
+afterAll(async () => {
+  await prismaBase.storeMembership.deleteMany({ where: { userId: ownerId } });
+  await prismaBase.tenant.updateMany({ where: { id: { in: createdTenantIds } }, data: { ownerUserId: null } });
+  await prismaBase.user.deleteMany({ where: { id: ownerId } });
+  await prismaBase.tenant.deleteMany({ where: { id: { in: createdTenantIds } } });
+  await prismaBase.$disconnect();
+});
+
+describe('POST /api/stores', () => {
+  it('provisions a pending store + membership + per-store billing email and starts a subscription', async () => {
+    mockInit.mockClear();
+    const res = await request(app)
+      .post('/api/stores')
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ name: 'Second Shop', planName: 'growth' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.authorizationUrl).toBe('https://checkout.paystack.com/xyz');
+    const newTenantId = res.body.tenantId as string;
+    expect(newTenantId).toBeDefined();
+    createdTenantIds.push(newTenantId);
+
+    const tenant = await prismaBase.tenant.findUnique({ where: { id: newTenantId } });
+    expect(tenant?.subscriptionStatus).toBe('pending');
+    expect(tenant?.ownerUserId).toBe(ownerId);
+    const expectedEmail = `prov-owner-${SUFFIX}+store-${tenant!.slug}@shop.com`;
+    expect(tenant?.billingEmail).toBe(expectedEmail);
+    expect(res.body.billingEmail).toBe(expectedEmail);
+
+    const membership = await prismaBase.storeMembership.findFirst({ where: { userId: ownerId, tenantId: newTenantId } });
+    expect(membership).not.toBeNull();
+    expect(membership?.isDefault).toBe(false);
+
+    // Distinct customer proof: the per-store email (not the owner's plain email)
+    // is what Paystack receives, plus metadata routing the correct tenant.
+    expect(mockInit).toHaveBeenCalledTimes(1);
+    const [email, planCode, amountMinor, metadata] = mockInit.mock.calls[0] as any[];
+    expect(email).toBe(expectedEmail);
+    expect(email).not.toBe(OWNER_EMAIL);
+    expect(planCode).toBe('PLN_growth_test');
+    expect(amountMinor).toBe(1500000); // 15000 NGN * 100, server-computed
+    expect(metadata).toMatchObject({ tenantId: newTenantId, kind: 'saas_subscription' });
+  });
+
+  it('issues a DISTINCT billing email (distinct customer) for a second new store', async () => {
+    const res = await request(app)
+      .post('/api/stores')
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ name: 'Third Shop', planName: 'growth' });
+    expect(res.status).toBe(201);
+    createdTenantIds.push(res.body.tenantId);
+
+    const second = await prismaBase.tenant.findUnique({ where: { id: createdTenantIds[1] }, select: { billingEmail: true } });
+    const third = await prismaBase.tenant.findUnique({ where: { id: res.body.tenantId }, select: { billingEmail: true } });
+    expect(third?.billingEmail).not.toBe(second?.billingEmail);
+  });
+
+  it('rejects a non-self-serve plan (400) and does not create a store or call Paystack', async () => {
+    mockInit.mockClear();
+    const before = await prismaBase.tenant.count({ where: { ownerUserId: ownerId } });
+    const res = await request(app)
+      .post('/api/stores')
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ name: 'Nope Shop', planName: 'enterprise' });
+    expect(res.status).toBe(400);
+    expect(mockInit).not.toHaveBeenCalled();
+    const after = await prismaBase.tenant.count({ where: { ownerUserId: ownerId } });
+    expect(after).toBe(before);
+  });
+
+  it('rejects a missing name (400)', async () => {
+    const res = await request(app)
+      .post('/api/stores')
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ planName: 'growth' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/src/__tests__/unit/nullTenantAlarm.test.ts
+++ b/backend/src/__tests__/unit/nullTenantAlarm.test.ts
@@ -1,0 +1,53 @@
+/**
+ * MAN-91: the auth.null_tenant_context tripwire must PAGE on-call, not just log.
+ *
+ * mintTokens is the single fail-closed mint surface. When no active store
+ * resolves (owner with no default membership, corrupt state), it must refuse to
+ * mint AND page on-call — that event is the alarm for the fail-open tenant
+ * extension. These tests mock the prisma + alerting seams and assert both.
+ */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import '../mocks/prisma.mock';
+import prismaMock from '../mocks/prisma.mock';
+
+jest.mock('../../utils/alerting', () => ({
+  __esModule: true,
+  pageOnCall: jest.fn(async () => {}),
+}));
+
+import { mintTokens } from '../../utils/mintTokens';
+import { pageOnCall } from '../../utils/alerting';
+
+const owner = { id: 42, email: 'owner@example.com', role: 'super_admin' as any, tenantId: null };
+
+describe('mintTokens null-tenant on-call tripwire (MAN-91)', () => {
+  beforeEach(() => {
+    (pageOnCall as jest.Mock).mockClear();
+  });
+
+  it('pages on-call and refuses to mint when no active store resolves', async () => {
+    (prismaMock.storeMembership.findFirst as any).mockResolvedValue(null);
+
+    await expect(mintTokens(owner)).rejects.toMatchObject({
+      statusCode: 403,
+      errorCode: 'TENANT_UNRESOLVED',
+    });
+
+    expect(pageOnCall).toHaveBeenCalledTimes(1);
+    expect(pageOnCall).toHaveBeenCalledWith(
+      'auth.null_tenant_context',
+      expect.objectContaining({ userId: 42, email: 'owner@example.com' }),
+    );
+  });
+
+  it('does NOT page and mints a scoped token when a default store resolves', async () => {
+    (prismaMock.storeMembership.findFirst as any).mockResolvedValue({ tenantId: 'tenant-1' });
+
+    const out = await mintTokens(owner);
+
+    expect(out.tenantId).toBe('tenant-1');
+    expect(typeof out.accessToken).toBe('string');
+    expect(out.accessToken.length).toBeGreaterThan(0);
+    expect(pageOnCall).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/__tests__/unit/platformBillingWebhook.test.ts
+++ b/backend/src/__tests__/unit/platformBillingWebhook.test.ts
@@ -103,6 +103,29 @@ describe('handlePlatformWebhook — SaaS subscription reconciliation', () => {
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
+  it('charge.success without metadata.tenantId resolves by subscription code, not customer code (MAN-90)', async () => {
+    const req = signedReq({
+      event: 'charge.success',
+      data: {
+        reference: 'ref_sub',
+        amount: 1000000,
+        metadata: { kind: 'saas_subscription' }, // no tenantId (renewal-style payload)
+        subscription_code: 'SUB_1',
+        customer: { customer_code: 'CUS_reused' },
+        next_payment_date: '2026-09-11T00:00:00.000Z',
+      },
+    });
+    const res = mockRes();
+    await handlePlatformWebhook(req, res);
+
+    const findFirstCalls = (prismaMock.tenant.findFirst as any).mock.calls;
+    // Routed by the unambiguous subscription code...
+    expect(findFirstCalls.some((c: any[]) => c[0]?.where?.paystackSubscriptionCode === 'SUB_1')).toBe(true);
+    // ...and never fell through to the customer-code lookup (it resolved first).
+    expect(findFirstCalls.some((c: any[]) => c[0]?.where?.paystackCustomerCode !== undefined)).toBe(false);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
   it('charge.success that is NOT a subscription charge is ignored (no tenant update)', async () => {
     const req = signedReq({
       event: 'charge.success',

--- a/backend/src/__tests__/unit/slug.test.ts
+++ b/backend/src/__tests__/unit/slug.test.ts
@@ -1,0 +1,33 @@
+/**
+ * MAN-89: perStoreBillingEmail is what gives each store a DISTINCT Paystack
+ * customer (plus-addressed alias of the owner's one inbox).
+ */
+import { describe, it, expect } from '@jest/globals';
+import { slugify, perStoreBillingEmail } from '../../utils/slug';
+
+describe('slugify', () => {
+  it('lowercases, hyphenates, and trims edge hyphens', () => {
+    expect(slugify('  Second Shop!! ')).toBe('second-shop');
+    expect(slugify('ACME & Co')).toBe('acme-co');
+  });
+});
+
+describe('perStoreBillingEmail (MAN-89)', () => {
+  it('plus-addresses the owner inbox with the store slug', () => {
+    expect(perStoreBillingEmail('owner@example.com', 'acme')).toBe('owner+store-acme@example.com');
+  });
+
+  it('strips an existing +tag so stores never stack tags', () => {
+    expect(perStoreBillingEmail('owner+store-old@example.com', 'acme')).toBe('owner+store-acme@example.com');
+  });
+
+  it('yields a DISTINCT email per store off the same inbox', () => {
+    const a = perStoreBillingEmail('owner@example.com', 'store-a');
+    const b = perStoreBillingEmail('owner@example.com', 'store-b');
+    expect(a).not.toBe(b);
+  });
+
+  it('leaves a non-addressable string unchanged', () => {
+    expect(perStoreBillingEmail('not-an-email', 'acme')).toBe('not-an-email');
+  });
+});

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -7,6 +7,7 @@ import { deleteStoreData, deleteOwnerReferences } from '../services/storeDeletio
 import { verifyRefreshToken } from '../utils/jwt';
 import { mintTokens, mintAccessToken } from '../utils/mintTokens';
 import { getCurrentUser, updateCurrentUser } from '../utils/currentUser';
+import { slugify } from '../utils/slug';
 import { AppError } from '../middleware/errorHandler';
 import { adminService } from '../services/adminService';
 import { sendPasswordResetEmail } from '../services/emailService';
@@ -298,15 +299,6 @@ export const me = async (req: AuthRequest, res: Response, next: NextFunction): P
 };
 
 // Slugify helper
-function slugify(str: string): string {
-  return str
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
-}
-
-
 export const registerTenant = async (req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
   try {
     const { companyName, adminEmail, adminPassword, adminName } = req.body;

--- a/backend/src/controllers/platformBillingWebhookController.ts
+++ b/backend/src/controllers/platformBillingWebhookController.ts
@@ -112,12 +112,23 @@ export async function handlePlatformWebhook(req: Request, res: Response): Promis
 async function resolveTenantForEvent(eventType: string, data: any): Promise<string | null> {
   switch (eventType) {
     case 'subscription.create':
+      // subscription.create is where we first LEARN the subscription code, so it
+      // can't route by it yet. customer code is the only link here, and MAN-89's
+      // per-store billing email keeps customers 1:1 with stores, so it is
+      // unambiguous.
       return resolveTenantByCustomerCode(data.customer?.customer_code);
     case 'charge.success': {
       // Only subscription charges concern us; ignore one-off charges.
       if (data.metadata?.kind !== 'saas_subscription') return null;
+      // MAN-90: route by unambiguous keys first — our own metadata.tenantId (set
+      // at init, present on the first charge) then the subscription code (the
+      // stable per-store key that holds even if a customer were ever reused).
+      // customer code is only a last resort for renewals whose payload carries
+      // neither; it is unambiguous post-MAN-89 (per-store customer) but is no
+      // longer the primary signal.
       return (
         (await resolveTenantById(data.metadata?.tenantId)) ||
+        (await resolveTenantBySubscriptionCode(data.subscription_code || data.subscription?.subscription_code)) ||
         (await resolveTenantByCustomerCode(data.customer?.customer_code))
       );
     }

--- a/backend/src/controllers/storeController.ts
+++ b/backend/src/controllers/storeController.ts
@@ -5,6 +5,9 @@ import { prismaBase } from '../utils/prisma';
 import { AppError } from '../middleware/errorHandler';
 import { mintTokens } from '../utils/mintTokens';
 import { deleteStoreData } from '../services/storeDeletionService';
+import { platformPaystackService } from '../services/platformPaystackService';
+import { slugify, perStoreBillingEmail } from '../utils/slug';
+import { SUBSCRIPTION_STATUS, SELF_SERVE_PLAN_NAMES } from '../config/billing';
 
 /**
  * GET /api/stores — list the stores the caller owns (their StoreMembership rows).
@@ -39,6 +42,94 @@ export const getStores = async (req: AuthRequest, res: Response, next: NextFunct
         isDefault: m.isDefault,
         isActive: m.tenantId === activeTenantId,
       })),
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * POST /api/stores — provision an ADDITIONAL store for the caller (MAN-89).
+ *
+ * Pay-before-materialize: create the Tenant as `pending` + the owner's
+ * StoreMembership + a per-store billing email, then kick off a Paystack
+ * subscription and hand back the authorization_url. The store stays `pending`
+ * (requireResolvedTenant 402s its data routes) until charge.success activates it
+ * via the platform webhook — this endpoint never marks a store active itself.
+ *
+ * The per-store billing email (owner+store-<slug>@domain) makes Paystack mint a
+ * DISTINCT customer per store, which is what makes webhook routing unambiguous.
+ *
+ * Not behind requireResolvedTenant: an owner provisions store 2 while their
+ * active store may be pending/none.
+ */
+export const createStore = async (req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    if (!req.user) throw new AppError('Unauthorized', 401);
+    const ownerEmail = req.user.email;
+    if (!ownerEmail) throw new AppError('Owner email required', 400);
+
+    const name = (req.body?.name ?? '').toString().trim();
+    if (!name) throw new AppError('name is required', 400);
+    const planName = (req.body?.planName ?? req.body?.planId)?.toString();
+    if (!planName) throw new AppError('planName is required', 400);
+
+    // Resolve + validate the plan up front (server-computed amount, never trusted
+    // from the client). Only self-serve tiers with a Paystack plan code + price.
+    const plan = await prismaBase.plan.findFirst({ where: { name: planName, isActive: true } });
+    if (!plan || !SELF_SERVE_PLAN_NAMES.includes(plan.name as any)) {
+      throw new AppError('Invalid plan selected. Choose Growth or Scale.', 400);
+    }
+    if (!plan.paystackPlanCode || plan.priceNGN == null) {
+      throw new AppError('This plan is not available for self-serve subscription', 400);
+    }
+
+    // Create the pending store + membership atomically. The owner user already
+    // exists (req.user), so ownerUserId is set inline — no two-step link.
+    const { tenantId, billingEmail } = await prismaBase.$transaction(async (tx) => {
+      const baseSlug = slugify(name) || 'store';
+      let slug = baseSlug;
+      let suffix = 1;
+      while (await tx.tenant.findUnique({ where: { slug } })) {
+        slug = `${baseSlug}-${suffix++}`;
+      }
+      const billingEmail = perStoreBillingEmail(ownerEmail, slug);
+      const tenant = await tx.tenant.create({
+        data: {
+          name,
+          slug,
+          currentPlanId: plan.id,
+          subscriptionStatus: SUBSCRIPTION_STATUS.PENDING,
+          billingEmail,
+          ownerUserId: req.user!.id,
+        },
+        select: { id: true },
+      });
+      await tx.storeMembership.create({
+        data: { userId: req.user!.id, tenantId: tenant.id, role: 'super_admin', isDefault: false },
+      });
+      return { tenantId: tenant.id, billingEmail };
+    });
+
+    // External Paystack call AFTER the store commit. If it fails, the store still
+    // exists as `pending`; the owner retries payment and its data routes stay
+    // locked until charge.success. Metadata carries tenantId so the webhook binds
+    // the correct store.
+    const amountMinor = Math.round(Number(plan.priceNGN) * 100);
+    const callbackUrl = `${process.env.FRONTEND_URL || 'http://localhost:5173'}/settings/billing/callback`;
+    const result = await platformPaystackService.initializeSubscriptionTransaction(
+      billingEmail,
+      plan.paystackPlanCode,
+      amountMinor,
+      { tenantId, planId: plan.id, planName: plan.name, kind: 'saas_subscription' },
+      callbackUrl,
+    );
+
+    res.status(201).json({
+      tenantId,
+      billingEmail,
+      authorizationUrl: result.authorization_url,
+      reference: result.reference,
     });
   } catch (error) {
     next(error);

--- a/backend/src/routes/storeRoutes.ts
+++ b/backend/src/routes/storeRoutes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { authenticate } from '../middleware/auth';
-import { getStores, switchStore, deleteStore } from '../controllers/storeController';
+import { getStores, createStore, switchStore, deleteStore } from '../controllers/storeController';
 
 const router = Router();
 
@@ -10,6 +10,7 @@ const router = Router();
 router.use(authenticate);
 
 router.get('/', getStores);
+router.post('/', createStore);
 router.post('/switch', switchStore);
 router.delete('/:id', deleteStore);
 

--- a/backend/src/routes/storeRoutes.ts
+++ b/backend/src/routes/storeRoutes.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { authenticate } from '../middleware/auth';
+import { authenticate, requireRole } from '../middleware/auth';
 import { getStores, createStore, switchStore, deleteStore } from '../controllers/storeController';
 
 const router = Router();
@@ -10,7 +10,10 @@ const router = Router();
 router.use(authenticate);
 
 router.get('/', getStores);
-router.post('/', createStore);
+// Provisioning starts a paid subscription, so it is super_admin (owner) only —
+// same gate as the billing/start-subscription routes. Listing + switching stay
+// open to any authenticated member.
+router.post('/', requireRole('super_admin'), createStore);
 router.post('/switch', switchStore);
 router.delete('/:id', deleteStore);
 

--- a/backend/src/utils/alerting.ts
+++ b/backend/src/utils/alerting.ts
@@ -1,0 +1,39 @@
+import logger from './logger';
+
+/**
+ * Route a critical operational event to on-call.
+ *
+ * Always logs at error level; when ALERT_WEBHOOK_URL is set (a Slack / generic
+ * incoming webhook) it ALSO POSTs a compact payload so the event pages a human,
+ * not just a log file nobody watches. Fire-safe: a failed page never throws back
+ * into the caller — the error log is the guaranteed fallback.
+ *
+ * MAN-91: the primary caller is the `auth.null_tenant_context` tripwire — the
+ * signal that a token was about to be minted with no active store, which is the
+ * fail-open crux of the tenant-scoping Prisma extension. That event must page,
+ * not merely log.
+ */
+export async function pageOnCall(event: string, context: Record<string, unknown> = {}): Promise<void> {
+  logger.error(`[oncall.page] ${event}`, context);
+
+  const url = process.env.ALERT_WEBHOOK_URL;
+  if (!url) return; // no pager configured — the error log above is the fallback
+
+  try {
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        text: `:rotating_light: ${event}`,
+        event,
+        context,
+        service: 'ecommerce-cod-api',
+        env: process.env.NODE_ENV ?? 'unknown',
+      }),
+    });
+  } catch (err: any) {
+    // A paging failure must not break the caller's path; the event is already
+    // in the error log. Record that delivery failed and move on.
+    logger.error('[oncall.page] failed to deliver alert', { event, error: err?.message });
+  }
+}

--- a/backend/src/utils/mintTokens.ts
+++ b/backend/src/utils/mintTokens.ts
@@ -1,7 +1,7 @@
 import { UserRole } from '@prisma/client';
 import { generateAccessToken, generateRefreshToken } from './jwt';
 import { prismaBase } from './prisma';
-import logger from './logger';
+import { pageOnCall } from './alerting';
 import { AppError } from '../middleware/errorHandler';
 
 /** Minimal user shape needed to mint a token. */
@@ -40,10 +40,13 @@ async function resolveOrThrow(user: MintableUser, explicitTenantId?: string | nu
   if (!tenantId) {
     // The fail-open crux: a null-tenant token makes auth.ts:162 run the request
     // UNSCOPED (the Prisma extension injects no filter on null context). Refuse
-    // to mint and page on-call via this structured tripwire instead.
-    logger.error(
-      `[auth.null_tenant_context] mintTokens could not resolve an active store for user ${user.id} (${user.email}); refusing to mint a null-tenant token`,
-    );
+    // to mint and PAGE on-call (MAN-91) — this tripwire must reach a human, not
+    // just sit in the error log.
+    await pageOnCall('auth.null_tenant_context', {
+      userId: user.id,
+      email: user.email,
+      detail: 'mintTokens could not resolve an active store; refused to mint a null-tenant token',
+    });
     throw new AppError('No active store resolved', 403, 'TENANT_UNRESOLVED');
   }
   return tenantId;

--- a/backend/src/utils/slug.ts
+++ b/backend/src/utils/slug.ts
@@ -1,0 +1,27 @@
+/**
+ * URL-safe slug from a display name: lowercase, non-alphanumerics collapsed to
+ * single hyphens, no leading/trailing hyphen. Shared by tenant registration and
+ * multi-store provisioning so both build slugs identically.
+ */
+export function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/**
+ * Per-store billing email (MAN-89). A plus-addressed alias of the owner's email
+ * (`owner@x.com` + store slug -> `owner+store-<slug>@x.com`) so Paystack keys a
+ * DISTINCT customer per store off the same inbox — which is what makes webhook
+ * routing by customer unambiguous. Any existing +tag on the owner's local part
+ * is stripped first so store N doesn't stack tags on store N-1.
+ */
+export function perStoreBillingEmail(ownerEmail: string, slug: string): string {
+  const at = ownerEmail.lastIndexOf('@');
+  if (at <= 0) return ownerEmail; // not an addressable email — leave as-is
+  const baseLocal = ownerEmail.slice(0, at).split('+')[0];
+  const domain = ownerEmail.slice(at + 1);
+  return `${baseLocal}+store-${slug}@${domain}`;
+}


### PR DESCRIPTION
## Billing lane — stacks on Owner-plumbing (#296)

Third lane of the multi-store-per-login sprint. Each store becomes its own paid Paystack subscription with a distinct customer, materialized only after payment succeeds.

### Issues
- **MAN-89** — `Tenant.billingEmail` + `POST /api/stores` pay-before-materialize provisioning. Creates a `pending` Tenant + owner StoreMembership with a per-store billing email (`owner+store-<slug>@…`) so Paystack mints a **distinct customer per store**; the store activates only on `charge.success`. Route is `super_admin`-gated.
- **MAN-90** — `charge.success` routes by `metadata.tenantId` → subscription code → (last resort) customer code. Prevents binding a payment to the wrong store.
- **MAN-91** — `pageOnCall` on-call alarm wired to the `auth.null_tenant_context` tripwire in `mintTokens`. (Webhook idempotency was already implemented + tested.)

### Security — /cso (diff vs owner-plumbing)
- **0 Critical, 1 High — FIXED before this PR** (`294264b`): `POST /api/stores` starts a paid subscription and was behind `authenticate` only; added `requireRole('super_admin')` + a 403 regression test to match sibling billing routes.
- Webhook routing HMAC-verified; amount server-computed from the Plan row; tenant+membership commit before the external Paystack call; store stays `pending` (402 on data routes) until activation.

### Tests
Full backend suite green (1104 passed). New: `storeProvision.test.ts` (provisioning + distinct-customer + 403 gate), `nullTenantAlarm.test.ts`, `platformBillingWebhook` subscription-code routing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)