### PR TITLE
release: deliveryDate on orders_update_status → production

### DIFF
--- a/backend/src/__tests__/integration/mcpOrdersUpdateStatus.test.ts
+++ b/backend/src/__tests__/integration/mcpOrdersUpdateStatus.test.ts
@@ -178,7 +178,7 @@ describe('orders_update_status MCP tool', () => {
         status: 'delivered',
         deliveryDate: '2026-06-17',
         notes: 'Logiswift ESD123 · shipped 2026-06-15',
-      } as any),
+      }),
     );
 
     expect(payload(res).updated).toBe(true);
@@ -189,9 +189,64 @@ describe('orders_update_status MCP tool', () => {
 
   it('rejects a malformed deliveryDate rather than silently using today', async () => {
     const res = await asTenant(tenantAId, () =>
-      updateOrderStatusTool({ orderId: orderAId, status: 'returned', deliveryDate: '17/06/2026' } as any),
+      updateOrderStatusTool({ orderId: orderAId, status: 'returned', deliveryDate: '17/06/2026' }),
     );
 
     expect(res.content[0].text).toMatch(/deliveryDate/i);
+  });
+
+  // These three cases exercise the calendar-validity guard on top of the
+  // schema's digit-shape regex. JS's Date silently rolls impossible calendar
+  // days into the next month (2026-02-30 -> 2026-03-02; 2026-02-29 ->
+  // 2026-03-01 since 2026 isn't a leap year), which would post GL revenue
+  // into the wrong accounting period if not caught. They run after the
+  // deliveryDate cases above, so orderAId is already 'delivered' with
+  // deliveryDate '2026-06-17'.
+  it('rejects a calendar-invalid deliveryDate (2026-02-30) instead of rolling it forward', async () => {
+    const res = await asTenant(tenantAId, () =>
+      updateOrderStatusTool({ orderId: orderAId, status: 'returned', deliveryDate: '2026-02-30' }),
+    );
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/deliveryDate/i);
+    expect(res.content[0].text).toMatch(/2026-02-30/);
+
+    const order = await prismaBase.order.findUniqueOrThrow({ where: { id: orderAId } });
+    expect(order.status).toBe('delivered');
+    expect(order.deliveryDate?.toISOString().slice(0, 10)).toBe('2026-06-17');
+  });
+
+  it('rejects Feb 29 in a non-leap year (2026-02-29) instead of rolling it forward', async () => {
+    const res = await asTenant(tenantAId, () =>
+      updateOrderStatusTool({ orderId: orderAId, status: 'returned', deliveryDate: '2026-02-29' }),
+    );
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/deliveryDate/i);
+    expect(res.content[0].text).toMatch(/2026-02-29/);
+
+    const order = await prismaBase.order.findUniqueOrThrow({ where: { id: orderAId } });
+    expect(order.status).toBe('delivered');
+    expect(order.deliveryDate?.toISOString().slice(0, 10)).toBe('2026-06-17');
+  });
+
+  it('still accepts a valid leap-year deliveryDate (2028-02-29)', async () => {
+    // Reset off 'delivered' first: the tool's idempotency guard would
+    // otherwise no-op a second 'delivered' call before deliveryDate is ever
+    // applied, since orderAId is already 'delivered' from the case above.
+    await asTenant(tenantAId, () =>
+      updateOrderStatusTool({ orderId: orderAId, status: 'confirmed' }),
+    );
+
+    const res = await asTenant(tenantAId, () =>
+      updateOrderStatusTool({ orderId: orderAId, status: 'delivered', deliveryDate: '2028-02-29' }),
+    );
+    const body = payload(res);
+
+    expect(res.isError).toBeUndefined();
+    expect(body.updated).toBe(true);
+
+    const order = await prismaBase.order.findUniqueOrThrow({ where: { id: orderAId } });
+    expect(order.deliveryDate?.toISOString().slice(0, 10)).toBe('2028-02-29');
   });
 });

--- a/backend/src/__tests__/integration/mcpOrdersUpdateStatus.test.ts
+++ b/backend/src/__tests__/integration/mcpOrdersUpdateStatus.test.ts
@@ -167,4 +167,31 @@ describe('orders_update_status MCP tool', () => {
     const orderB = await prismaBase.order.findUnique({ where: { id: orderBId } });
     expect(orderB?.status).toBe('confirmed');
   });
+
+  // These two cases move orderAId into the inventory-deducted zone
+  // (delivered), so they must run last, after all cases above that assume
+  // `confirmed -> preparing`.
+  it('honours an explicit deliveryDate when marking delivered', async () => {
+    const res = await asTenant(tenantAId, () =>
+      updateOrderStatusTool({
+        orderId: orderAId,
+        status: 'delivered',
+        deliveryDate: '2026-06-17',
+        notes: 'Logiswift ESD123 · shipped 2026-06-15',
+      } as any),
+    );
+
+    expect(payload(res).updated).toBe(true);
+
+    const order = await prismaBase.order.findUniqueOrThrow({ where: { id: orderAId } });
+    expect(order.deliveryDate?.toISOString().slice(0, 10)).toBe('2026-06-17');
+  });
+
+  it('rejects a malformed deliveryDate rather than silently using today', async () => {
+    const res = await asTenant(tenantAId, () =>
+      updateOrderStatusTool({ orderId: orderAId, status: 'returned', deliveryDate: '17/06/2026' } as any),
+    );
+
+    expect(res.content[0].text).toMatch(/deliveryDate/i);
+  });
 });

--- a/backend/src/__tests__/integration/orderStatusDeliveryDate.test.ts
+++ b/backend/src/__tests__/integration/orderStatusDeliveryDate.test.ts
@@ -1,0 +1,93 @@
+/**
+ * The Logiswift backfill marks June deliveries as delivered in July. If the
+ * service keeps hardcoding `new Date()`, financialSyncService stamps the GL
+ * collection date with today (financialSyncService.ts:144) and June's revenue
+ * lands in July's period. These tests pin the fix.
+ */
+import { jest, describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { prismaBase } from '../../utils/prisma';
+import { tenantStorage } from '../../utils/tenantContext';
+import orderService from '../../services/orderService';
+
+jest.mock('../../utils/socketInstance', () => ({
+  setSocketInstance: jest.fn(),
+  getSocketInstance: jest.fn(() => ({
+    to: jest.fn(() => ({ emit: jest.fn() })),
+    emit: jest.fn(),
+  })),
+  hasSocketInstance: jest.fn(() => true),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+const SUFFIX = Date.now();
+let tenantId: string;
+let orderIds: number[] = [];
+
+beforeAll(async () => {
+  const tenant = await prismaBase.tenant.create({
+    data: { name: `DD Tenant ${SUFFIX}`, slug: `dd-${SUFFIX}` },
+  });
+  tenantId = tenant.id;
+
+  const customer = await prismaBase.customer.create({
+    data: {
+      firstName: 'Kofi', lastName: 'Owusu',
+      phoneNumber: `+2332${SUFFIX}`.slice(0, 15),
+      address: '2 Test Rd', state: 'Greater Accra', area: 'Accra', tenantId,
+    },
+  });
+
+  // Two orders: one gets an explicit date, one gets none.
+  for (let i = 0; i < 2; i++) {
+    const order = await prismaBase.order.create({
+      data: {
+        customerId: customer.id, status: 'confirmed',
+        subtotal: 100, shippingCost: 0, totalAmount: 100,
+        deliveryAddress: '2 Test Rd', deliveryState: 'Greater Accra', deliveryArea: 'Accra',
+        tenantId,
+      },
+    });
+    orderIds.push(order.id);
+  }
+});
+
+afterAll(async () => {
+  await prismaBase.orderHistory.deleteMany({ where: { orderId: { in: orderIds } } });
+  await prismaBase.order.deleteMany({ where: { id: { in: orderIds } } });
+  await prismaBase.customer.deleteMany({ where: { tenantId } });
+  await prismaBase.tenant.delete({ where: { id: tenantId } });
+  await prismaBase.$disconnect();
+});
+
+describe('updateOrderStatus deliveryDate', () => {
+  it('uses the supplied deliveryDate when marking delivered', async () => {
+    const backdated = new Date('2026-06-17T00:00:00.000Z');
+
+    await tenantStorage.run({ tenantId }, () =>
+      orderService.updateOrderStatus(orderIds[0], {
+        status: 'delivered',
+        deliveryDate: backdated,
+        notes: 'Logiswift ESD123 · shipped 2026-06-15',
+      }),
+    );
+
+    const order = await prismaBase.order.findUniqueOrThrow({ where: { id: orderIds[0] } });
+    expect(order.deliveryDate?.toISOString()).toBe(backdated.toISOString());
+    expect(order.paymentStatus).toBe('collected');
+  });
+
+  it('falls back to now when no deliveryDate is supplied', async () => {
+    const before = Date.now();
+
+    await tenantStorage.run({ tenantId }, () =>
+      orderService.updateOrderStatus(orderIds[1], { status: 'delivered' }),
+    );
+
+    const order = await prismaBase.order.findUniqueOrThrow({ where: { id: orderIds[1] } });
+    expect(order.deliveryDate!.getTime()).toBeGreaterThanOrEqual(before);
+  });
+});

--- a/backend/src/mcp/tools/ordersWrite.ts
+++ b/backend/src/mcp/tools/ordersWrite.ts
@@ -92,7 +92,7 @@ export async function updateOrderStatusTool(args: z.infer<typeof ordersUpdateSta
     await orderService.updateOrderStatus(parsed.orderId, {
       status: parsed.status,
       notes: parsed.notes ?? 'Status updated via MCP',
-      ...(deliveryDate ? { deliveryDate } : {}),
+      deliveryDate,
     });
 
     return mcpJson({

--- a/backend/src/mcp/tools/ordersWrite.ts
+++ b/backend/src/mcp/tools/ordersWrite.ts
@@ -35,6 +35,21 @@ export async function updateOrderStatusTool(args: z.infer<typeof ordersUpdateSta
   try {
     const parsed = ordersUpdateStatusSchema.parse(args);
 
+    // Calendar validity check, on top of the schema's digit-shape regex.
+    // JS silently rolls impossible calendar days into the next month (e.g.
+    // 2026-02-30 -> 2026-03-02, 2026-02-29 -> 2026-03-01 since 2026 isn't a
+    // leap year), which would post GL revenue into the wrong accounting
+    // period. Round-tripping through toISOString catches both an outright
+    // Invalid Date and this silent rollover in one check.
+    let deliveryDate: Date | undefined;
+    if (parsed.deliveryDate) {
+      const candidate = new Date(`${parsed.deliveryDate}T00:00:00.000Z`);
+      if (candidate.toISOString().slice(0, 10) !== parsed.deliveryDate) {
+        return mcpError(`deliveryDate "${parsed.deliveryDate}" is not a valid calendar date`);
+      }
+      deliveryDate = candidate;
+    }
+
     // Tenant-scoped lookup. findFirst passes through the tenant-isolation
     // Prisma extension, so an orderId belonging to another tenant simply
     // returns null — this tool can never mutate another store's order.
@@ -77,7 +92,7 @@ export async function updateOrderStatusTool(args: z.infer<typeof ordersUpdateSta
     await orderService.updateOrderStatus(parsed.orderId, {
       status: parsed.status,
       notes: parsed.notes ?? 'Status updated via MCP',
-      ...(parsed.deliveryDate ? { deliveryDate: new Date(`${parsed.deliveryDate}T00:00:00.000Z`) } : {}),
+      ...(deliveryDate ? { deliveryDate } : {}),
     });
 
     return mcpJson({

--- a/backend/src/mcp/tools/ordersWrite.ts
+++ b/backend/src/mcp/tools/ordersWrite.ts
@@ -21,6 +21,9 @@ const ordersUpdateStatusSchema = z.object({
     'failed_delivery',
   ]),
   notes: z.string().max(500).optional(),
+  // The real delivery date, for 3PL reconciliation where delivery happened days
+  // ago. Only meaningful with status "delivered". Omitted => now.
+  deliveryDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'deliveryDate must be YYYY-MM-DD').optional(),
 });
 
 /**
@@ -74,6 +77,7 @@ export async function updateOrderStatusTool(args: z.infer<typeof ordersUpdateSta
     await orderService.updateOrderStatus(parsed.orderId, {
       status: parsed.status,
       notes: parsed.notes ?? 'Status updated via MCP',
+      ...(parsed.deliveryDate ? { deliveryDate: new Date(`${parsed.deliveryDate}T00:00:00.000Z`) } : {}),
     });
 
     return mcpJson({
@@ -95,7 +99,7 @@ export function registerOrderWriteTools(
 ) {
   server.tool(
     'orders_update_status',
-    'Update an order\'s fulfillment status. Writes an order-history audit row and, via the shared order service, adjusts inventory and (on delivered/returned) payment status and accounting entries. Idempotent: makes no change if the order is already in the requested status. Valid statuses: pending_confirmation, confirmed, preparing, ready_for_pickup, out_for_delivery, delivered, cancelled, returned, failed_delivery.',
+    'Update an order\'s fulfillment status. Writes an order-history audit row and, via the shared order service, adjusts inventory and (on delivered/returned) payment status and accounting entries. Idempotent: makes no change if the order is already in the requested status. Valid statuses: pending_confirmation, confirmed, preparing, ready_for_pickup, out_for_delivery, delivered, cancelled, returned, failed_delivery. Optionally accepts deliveryDate (YYYY-MM-DD) to record when a delivery actually happened — use it when reconciling past deliveries from a 3PL, otherwise the delivery date defaults to now.',
     ordersUpdateStatusSchema.shape,
     wrapHandler(updateOrderStatusTool),
   );

--- a/backend/src/services/orderService.ts
+++ b/backend/src/services/orderService.ts
@@ -86,6 +86,10 @@ interface UpdateOrderStatusData {
   status: OrderStatus;
   notes?: string;
   changedBy?: number;
+  // Explicit delivery date, for backfills from a 3PL where the real delivery
+  // happened days ago. Omitted => now. financialSyncService uses this as the
+  // GL collection date, so a wrong value posts revenue into the wrong period.
+  deliveryDate?: Date;
 }
 
 export class OrderService {
@@ -1153,7 +1157,7 @@ export class OrderService {
         where: { id: orderId },
         data: {
           status: data.status,
-          deliveryDate: data.status === 'delivered' ? new Date() : undefined,
+          deliveryDate: data.status === 'delivered' ? (data.deliveryDate ?? new Date()) : undefined,
           paymentStatus: data.status === 'delivered' ? 'collected' : order.paymentStatus,
           ...(isReturnStatus && order.revenueRecognized ? { revenueRecognized: false } : {}),
           orderHistory: {


### PR DESCRIPTION
Promotes PR #298 to production.

Adds an optional `deliveryDate` (YYYY-MM-DD) to `orders_update_status` / `orderService.updateOrderStatus`, so the upcoming Logiswift 3PL backfill stamps the real historical delivery date instead of today — keeping recognized COD revenue in the correct GL period. Includes a calendar-validity guard rejecting impossible dates (e.g. 2026-02-30) that JS would otherwise silently roll into the next month.

Merged and green on develop; staging deploy succeeded. Only diff over main is the 4 commits from #298 plus its merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)