### PR TITLE
fix(checkout): stop dropping orders from mislabelled fields and archived customers

### DIFF
--- a/backend/src/__tests__/unit/auth.test.ts
+++ b/backend/src/__tests__/unit/auth.test.ts
@@ -159,6 +159,25 @@ describe('Auth Controller', () => {
         expect.objectContaining({ message: 'User already exists' })
       );
     });
+
+    // A deactivated user still owns their email in the unique index. Before the
+    // lookup opted out of the soft-delete filter it returned null here, the
+    // create ran, and Postgres rejected it — surfacing as a 500 on a public route.
+    it('rejects a deactivated account with the same 400, never reaching create', async () => {
+      mockReq.body = {
+        email: 'deactivated@example.com',
+        password: 'password123',
+      };
+
+      prismaMock.user.findUnique.mockResolvedValue({ id: '123', isActive: false } as any);
+
+      await register(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'User already exists' })
+      );
+      expect(prismaMock.user.create).not.toHaveBeenCalled();
+    });
   });
 
   describe('refresh', () => {

--- a/backend/src/__tests__/unit/checkoutFormService.test.ts
+++ b/backend/src/__tests__/unit/checkoutFormService.test.ts
@@ -72,6 +72,19 @@ describe('CheckoutFormService', () => {
       await expect(checkoutFormService.createCheckoutForm(makeCreateData())).rejects.toThrow(AppError);
     });
 
+    // An archived form keeps its slug in the unique index, so the duplicate check
+    // has to see it. The message names the archive so the merchant knows to
+    // restore it rather than wondering why a slug they can't see is taken.
+    it('names the archive when an archived form holds the slug', async () => {
+      (prismaMock.checkoutForm.findFirst as any).mockResolvedValue(
+        makeForm({ isActive: false }) as any
+      );
+
+      await expect(checkoutFormService.createCheckoutForm(makeCreateData())).rejects.toThrow(
+        /archived checkout form already uses this slug/i
+      );
+    });
+
     it('throws 404 when product not found', async () => {
       (prismaMock.checkoutForm.findFirst as any).mockResolvedValue(null);
       (prismaMock.product.findUnique as any).mockResolvedValue(null);
@@ -240,6 +253,20 @@ describe('CheckoutFormService', () => {
 
       const result = await checkoutFormService.updateCheckoutForm('1', { name: 'Updated' });
       expect(result).toBeDefined();
+    });
+
+    // Same archived-slug case as create, on the rename path.
+    it('names the archive when renaming onto a slug an archived form holds', async () => {
+      (prismaMock.checkoutForm.findUnique as any).mockResolvedValue(
+        makeForm({ slug: 'original', packages: [], upsells: [] }) as any
+      );
+      (prismaMock.checkoutForm.findFirst as any).mockResolvedValue(
+        makeForm({ slug: 'taken', isActive: false }) as any
+      );
+
+      await expect(
+        checkoutFormService.updateCheckoutForm('1', { slug: 'taken' })
+      ).rejects.toThrow(/archived checkout form already uses this slug/i);
     });
   });
 

--- a/backend/src/__tests__/unit/productController.test.ts
+++ b/backend/src/__tests__/unit/productController.test.ts
@@ -1,0 +1,66 @@
+/**
+ * productController.createProduct — SKU uniqueness.
+ *
+ * The SKU check has to see archived products: an archived row keeps its SKU in
+ * the unique index, so a check blind to it lets the create through and Postgres
+ * rejects it. Nothing maps that constraint error for this route, so it reached
+ * the client as a 500 "Internal server error".
+ */
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { prismaMock } from '../mocks/prisma.mock';
+import { createProduct } from '../../controllers/productController';
+
+describe('productController.createProduct — SKU uniqueness', () => {
+  let mockReq: any;
+  let mockRes: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockReq = { body: { name: 'Test Product', sku: 'SKU-001', price: 100 }, user: null };
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+  });
+
+  it('creates the product when the SKU is free', async () => {
+    (prismaMock.product.findFirst as any).mockResolvedValue(null);
+    (prismaMock.product.create as any).mockResolvedValue({ id: 1, sku: 'SKU-001' } as any);
+
+    await createProduct(mockReq, mockRes);
+
+    expect(mockRes.status).toHaveBeenCalledWith(201);
+  });
+
+  it('rejects an active duplicate with the existing message', async () => {
+    (prismaMock.product.findFirst as any).mockResolvedValue({
+      id: 1,
+      sku: 'SKU-001',
+      isActive: true,
+    } as any);
+
+    await expect(createProduct(mockReq, mockRes)).rejects.toThrow(
+      'Product with this SKU already exists'
+    );
+    expect(prismaMock.product.create).not.toHaveBeenCalled();
+  });
+
+  it('points at the archived product rather than failing on the constraint', async () => {
+    (prismaMock.product.findFirst as any).mockResolvedValue({
+      id: 1,
+      sku: 'SKU-001',
+      isActive: false,
+    } as any);
+
+    await expect(createProduct(mockReq, mockRes)).rejects.toThrow(
+      /archived product already uses this SKU/i
+    );
+    expect(prismaMock.product.create).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/__tests__/unit/publicOrderController.test.ts
+++ b/backend/src/__tests__/unit/publicOrderController.test.ts
@@ -24,9 +24,19 @@ jest.mock('../../services/metaCapiService', () => ({
 jest.mock('../../sockets', () => ({ emitOrderCreated: jest.fn() }));
 jest.mock('../../utils/socketInstance', () => ({ getSocketInstance: jest.fn() }));
 
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
 import { prismaMock } from '../mocks/prisma.mock';
 import * as paystackServiceModule from '../../services/paystackService';
 import { createPublicOrder } from '../../controllers/publicOrderController';
+import logger from '../../utils/logger';
+import workflowService from '../../services/workflowService';
+import { metaCapiService } from '../../services/metaCapiService';
+
+const mockedLogger = logger as jest.Mocked<typeof logger>;
 
 const mockedPaystack = paystackServiceModule.paystackService as jest.Mocked<
   typeof paystackServiceModule.paystackService
@@ -243,6 +253,122 @@ describe('publicOrderController.createPublicOrder — email linking (issue #1)',
       expect.objectContaining({
         where: { id: 7 },
         data: expect.objectContaining({ email: 'new@x.com' }),
+      }),
+    );
+  });
+});
+
+// Archiving a customer only flips `isActive` to false; the row keeps the phone
+// number's slot in the @@unique([phoneNumber, tenantId]) index. The soft-delete
+// extension hides it from reads, so the old find-then-create path found nothing,
+// tried to create a duplicate, and returned a 500 — every repeat buyer whose
+// record had ever been archived was permanently locked out of the checkout.
+describe('publicOrderController.createPublicOrder — archived customers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function codOrderMocks() {
+    // The completed-order path calls .catch() on both of these, and
+    // clearAllMocks() strips the module-level implementations — so they have to
+    // be re-armed here or the controller throws after the order is created.
+    (workflowService.triggerOrderCreatedWorkflows as any).mockResolvedValue(undefined);
+    (metaCapiService.fireCapiPurchaseEvent as any).mockResolvedValue(undefined);
+    (prismaMock.checkoutForm.findFirst as any).mockResolvedValue(physicalForm());
+    (prismaMock.formSubmission.findFirst as any).mockResolvedValue(null);
+    (prismaMock.order.findFirst as any).mockResolvedValue(null);
+    (prismaMock.order.create as any).mockResolvedValue({
+      id: 55, totalAmount: 250, status: 'pending_confirmation', orderType: 'physical',
+    });
+    (prismaMock.formSubmission.create as any).mockResolvedValue({ id: 1 });
+  }
+
+  it('reactivates an archived customer instead of creating a duplicate', async () => {
+    codOrderMocks();
+    const archived = {
+      id: 7, firstName: 'Ama', lastName: 'Mensah', phoneNumber: buyer.phoneNumber,
+      email: null, alternatePhone: null, isActive: false,
+    };
+    (prismaMock.customer.findFirst as any).mockResolvedValue(archived);
+    (prismaMock.customer.update as any).mockResolvedValue({ ...archived, isActive: true });
+
+    const res = buildRes();
+    await createPublicOrder(
+      buildReq({ formData: buyer, selectedPackage: { id: 10 }, paymentMethod: 'cod', totalAmount: 250 }),
+      res,
+      jest.fn(),
+    );
+
+    // The archived record is restored, not duplicated — a create here would hit
+    // the unique constraint and 500.
+    expect(prismaMock.customer.update).toHaveBeenCalledWith({
+      where: { id: 7 },
+      data: { isActive: true },
+    });
+    expect(prismaMock.customer.create).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it('leaves an active customer untouched', async () => {
+    codOrderMocks();
+    (prismaMock.customer.findFirst as any).mockResolvedValue({
+      id: 7, firstName: 'Ama', lastName: 'Mensah', phoneNumber: buyer.phoneNumber,
+      email: null, alternatePhone: null, isActive: true,
+    });
+
+    await createPublicOrder(
+      buildReq({ formData: buyer, selectedPackage: { id: 10 }, paymentMethod: 'cod', totalAmount: 250 }),
+      buildRes(),
+      jest.fn(),
+    );
+
+    // The order still increments the customer's totals; what must NOT happen is
+    // a reactivation write against a customer who was never archived.
+    expect(prismaMock.customer.update).not.toHaveBeenCalledWith({
+      where: { id: 7 },
+      data: { isActive: true },
+    });
+    expect(prismaMock.customer.create).not.toHaveBeenCalled();
+  });
+});
+
+// A rejected submission is a buyer who tried to order and got nothing. These
+// used to return silently, which let a tenant sit at zero orders for days with
+// no signal — the log line is the fix for that, so it's asserted like behaviour.
+describe('publicOrderController.createPublicOrder — rejection logging', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs a missing required field with the keys the form did send', async () => {
+    (prismaMock.checkoutForm.findFirst as any).mockResolvedValue(physicalForm());
+    const res = buildRes();
+
+    await createPublicOrder(
+      buildReq({
+        // What a form whose address field doesn't map produces: the buyer typed
+        // an address, but it arrived as a custom field and `address` is empty.
+        formData: {
+          name: 'Ama Mensah',
+          phoneNumber: '0241234567',
+          state: 'Greater Accra',
+          customFields: { 'Delivery Address': '12 Test Street' },
+        },
+        selectedPackage: { id: 10 },
+        paymentMethod: 'cod',
+        totalAmount: 250,
+      }),
+      res,
+      jest.fn(),
+    );
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockedLogger.warn).toHaveBeenCalledWith(
+      'Public checkout submission rejected',
+      expect.objectContaining({
+        slug: 'form-1',
+        reason: 'Missing required field: address',
+        customFieldKeys: ['Delivery Address'],
       }),
     );
   });

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -3,6 +3,7 @@ import crypto from 'crypto';
 import bcrypt from 'bcrypt';
 import { AuthRequest } from '../types';
 import prisma from '../utils/prisma';
+import { withSoftDeleted } from '../utils/prismaExtensions';
 import { generateAccessToken, generateRefreshToken, verifyRefreshToken } from '../utils/jwt';
 import { AppError } from '../middleware/errorHandler';
 import { adminService } from '../services/adminService';
@@ -17,7 +18,12 @@ export const register = async (req: AuthRequest, res: Response, next: NextFuncti
       throw new AppError('Password is required and must be 72 characters or fewer', 400);
     }
 
-    const existingUser = await prisma.user.findUnique({ where: { email } });
+    // Deactivated users still hold their email in the unique index, and the
+    // soft-delete extension hides them from this check — so without the opt-out
+    // the create below dies on a constraint violation (500) instead of the 400.
+    // The message is deliberately identical for active and deactivated accounts:
+    // this route is public, so it must not disclose an account's state.
+    const existingUser = await withSoftDeleted(() => prisma.user.findUnique({ where: { email } }));
     if (existingUser) {
       throw new AppError('User already exists', 400);
     }
@@ -360,8 +366,11 @@ export const registerTenant = async (req: AuthRequest, res: Response, next: Next
 
     // All uniqueness checks + creation inside a single transaction to prevent TOCTOU races
     const { tenant, user } = await prisma.$transaction(async (tx) => {
-      // Check email uniqueness inside transaction
-      const existing = await tx.user.findUnique({ where: { email: adminEmail } });
+      // Check email uniqueness inside transaction. Deactivated users still hold
+      // the email in the unique index, so this opts out of the soft-delete filter
+      // — the P2002 catch below would otherwise turn a deactivated account into a
+      // rolled-back transaction rather than this clean 400.
+      const existing = await withSoftDeleted(() => tx.user.findUnique({ where: { email: adminEmail } }));
       if (existing) {
         throw new AppError('An account with this email already exists', 400);
       }

--- a/backend/src/controllers/productController.ts
+++ b/backend/src/controllers/productController.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express';
 import { AuthRequest } from '../types';
 import prisma from '../utils/prisma';
+import { withSoftDeleted } from '../utils/prismaExtensions';
 import { AppError } from '../middleware/errorHandler';
 
 
@@ -52,14 +53,24 @@ export const createProduct = async (req: AuthRequest, res: Response): Promise<vo
 
     const productData = req.body;
 
-    const existingProduct = await prisma.product.findFirst({
-      where: {
-        sku: productData.sku
-      }
-    });
+    // Archived products keep their SKU in the unique index, so this check has to
+    // see past the soft-delete filter — otherwise the create below fails on the
+    // constraint with a 500 instead of returning this 400.
+    const existingProduct = await withSoftDeleted(() =>
+      prisma.product.findFirst({
+        where: {
+          sku: productData.sku
+        }
+      })
+    );
 
     if (existingProduct) {
-      throw new AppError('Product with this SKU already exists', 400);
+      throw new AppError(
+        existingProduct.isActive === false
+          ? 'An archived product already uses this SKU. Restore that product instead.'
+          : 'Product with this SKU already exists',
+        400
+      );
     }
 
     const product = await prisma.product.create({

--- a/backend/src/controllers/publicOrderController.ts
+++ b/backend/src/controllers/publicOrderController.ts
@@ -5,6 +5,8 @@ import checkoutFormService from '../services/checkoutFormService';
 import { getSocketInstance } from '../utils/socketInstance';
 import { emitOrderCreated } from '../sockets';
 import prisma from '../utils/prisma';
+import { findAndReactivateCustomerByPhone } from '../utils/customerLookup';
+import logger from '../utils/logger';
 import { paystackService } from '../services/paystackService';
 import { metaCapiService } from '../services/metaCapiService';
 
@@ -74,6 +76,35 @@ export const getPublicFormConfig = async (req: Request, res: Response, next: Nex
   }
 };
 
+/**
+ * Rejects a checkout submission with a 400 and logs why.
+ *
+ * Every rejection here is a buyer who tried to order and got nothing, so each one
+ * needs a trace. Without it an entire tenant can sit at zero orders with no
+ * signal anywhere — which is what happened when a form labelled its address field
+ * something the checkout didn't recognise: the value never reached `address`, the
+ * submission was dropped, and nothing was written down. `presentKeys` /
+ * `customFieldKeys` name what the form actually sent (keys only, no buyer data),
+ * so a field-mapping fault is diagnosable from the log line alone.
+ */
+function rejectSubmission(
+  res: Response,
+  slug: string,
+  reason: string,
+  formData: Record<string, unknown> | undefined
+): void {
+  const present = (obj: Record<string, unknown> | undefined): string[] =>
+    obj ? Object.keys(obj).filter((k) => obj[k] !== undefined && obj[k] !== null && obj[k] !== '') : [];
+
+  logger.warn('Public checkout submission rejected', {
+    slug,
+    reason,
+    presentKeys: present(formData),
+    customFieldKeys: Object.keys((formData?.customFields as Record<string, unknown>) || {}),
+  });
+  res.status(400).json({ error: reason });
+}
+
 export const createPublicOrder = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const { slug } = req.params;
@@ -111,7 +142,7 @@ export const createPublicOrder = async (req: Request, res: Response, next: NextF
     }
 
     if (!form.product.isActive) {
-      res.status(400).json({ error: 'Product is no longer available' });
+      rejectSubmission(res, slug, 'Product is no longer available', formData);
       return;
     }
 
@@ -137,7 +168,7 @@ export const createPublicOrder = async (req: Request, res: Response, next: NextF
         paystack_full: form.paystackFullEnabled,
       };
       if (!enabledFor[paymentMethod]) {
-        res.status(400).json({ error: 'Selected payment method is not available for this form' });
+        rejectSubmission(res, slug, 'Selected payment method is not available for this form', formData);
         return;
       }
     }
@@ -149,7 +180,7 @@ export const createPublicOrder = async (req: Request, res: Response, next: NextF
       : ['name', 'phoneNumber', 'address', 'state'];
     for (const field of requiredFields) {
       if (!formData[field]) {
-        res.status(400).json({ error: `Missing required field: ${field}` });
+        rejectSubmission(res, slug, `Missing required field: ${field}`, formData);
         return;
       }
     }
@@ -157,21 +188,29 @@ export const createPublicOrder = async (req: Request, res: Response, next: NextF
     // Paystack orders settle into the form's tenant Paystack account; without
     // a tenant we'd create an orphaned unpaid order. Fail fast before any DB write.
     if (isPaystack && !formTenantId) {
-      res.status(400).json({
-        error: 'This checkout form is not attached to a tenant; Paystack cannot be initialized.',
-      });
+      rejectSubmission(
+        res,
+        slug,
+        'This checkout form is not attached to a tenant; Paystack cannot be initialized.',
+        formData
+      );
       return;
     }
 
     if (isDigital && !formData.email) {
-      res.status(400).json({ error: 'Email is required for digital products' });
+      rejectSubmission(res, slug, 'Email is required for digital products', formData);
       return;
     }
 
-    // Check if customer exists or create new one (scoped to tenant)
-    let customer = await prisma.customer.findFirst({
-      where: { phoneNumber: formData.phoneNumber, ...(formTenantId ? { tenantId: formTenantId } : {}) }
-    });
+    // Check if customer exists or create new one (scoped to tenant). Archived
+    // customers are found and reactivated — they still hold the phone number's
+    // slot in the unique index, so creating past them would 500.
+    let customer = await findAndReactivateCustomerByPhone(
+      prisma,
+      formData.phoneNumber,
+      formTenantId,
+      'public checkout'
+    );
 
     if (!customer) {
       const nameParts = formData.name.split(' ');

--- a/backend/src/controllers/publicOrderController.ts
+++ b/backend/src/controllers/publicOrderController.ts
@@ -76,35 +76,6 @@ export const getPublicFormConfig = async (req: Request, res: Response, next: Nex
   }
 };
 
-/**
- * Rejects a checkout submission with a 400 and logs why.
- *
- * Every rejection here is a buyer who tried to order and got nothing, so each one
- * needs a trace. Without it an entire tenant can sit at zero orders with no
- * signal anywhere — which is what happened when a form labelled its address field
- * something the checkout didn't recognise: the value never reached `address`, the
- * submission was dropped, and nothing was written down. `presentKeys` /
- * `customFieldKeys` name what the form actually sent (keys only, no buyer data),
- * so a field-mapping fault is diagnosable from the log line alone.
- */
-function rejectSubmission(
-  res: Response,
-  slug: string,
-  reason: string,
-  formData: Record<string, unknown> | undefined
-): void {
-  const present = (obj: Record<string, unknown> | undefined): string[] =>
-    obj ? Object.keys(obj).filter((k) => obj[k] !== undefined && obj[k] !== null && obj[k] !== '') : [];
-
-  logger.warn('Public checkout submission rejected', {
-    slug,
-    reason,
-    presentKeys: present(formData),
-    customFieldKeys: Object.keys((formData?.customFields as Record<string, unknown>) || {}),
-  });
-  res.status(400).json({ error: reason });
-}
-
 export const createPublicOrder = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const { slug } = req.params;
@@ -119,6 +90,29 @@ export const createPublicOrder = async (req: Request, res: Response, next: NextF
     // Purchase CAPI event (COD fires now; Paystack carries them via PendingCheckout).
     const fbp = clampTracking(req.body.fbp);
     const fbc = clampTracking(req.body.fbc);
+
+    // Rejects this submission with a 400 and logs why.
+    //
+    // Every rejection here is a buyer who tried to order and got nothing, so each
+    // one needs a trace. Without it an entire tenant can sit at zero orders with no
+    // signal anywhere — which is what happened when a form labelled its address
+    // field something the checkout didn't recognise: the value never reached
+    // `address`, the submission was dropped, and nothing was written down.
+    // `presentKeys` / `customFieldKeys` name what the form actually sent (keys
+    // only, no buyer data), so a field-mapping fault is diagnosable from the log
+    // line alone.
+    const reject = (reason: string): void => {
+      const data = formData as Record<string, unknown> | undefined;
+      logger.warn('Public checkout submission rejected', {
+        slug,
+        reason,
+        presentKeys: data
+          ? Object.keys(data).filter((k) => data[k] !== undefined && data[k] !== null && data[k] !== '')
+          : [],
+        customFieldKeys: Object.keys((data?.customFields as Record<string, unknown>) || {}),
+      });
+      res.status(400).json({ error: reason });
+    };
 
     // Get form with product — the form's tenantId determines the tenant context
     // for this unauthenticated request
@@ -142,7 +136,7 @@ export const createPublicOrder = async (req: Request, res: Response, next: NextF
     }
 
     if (!form.product.isActive) {
-      rejectSubmission(res, slug, 'Product is no longer available', formData);
+      reject('Product is no longer available');
       return;
     }
 
@@ -168,7 +162,7 @@ export const createPublicOrder = async (req: Request, res: Response, next: NextF
         paystack_full: form.paystackFullEnabled,
       };
       if (!enabledFor[paymentMethod]) {
-        rejectSubmission(res, slug, 'Selected payment method is not available for this form', formData);
+        reject('Selected payment method is not available for this form');
         return;
       }
     }
@@ -180,7 +174,7 @@ export const createPublicOrder = async (req: Request, res: Response, next: NextF
       : ['name', 'phoneNumber', 'address', 'state'];
     for (const field of requiredFields) {
       if (!formData[field]) {
-        rejectSubmission(res, slug, `Missing required field: ${field}`, formData);
+        reject(`Missing required field: ${field}`);
         return;
       }
     }
@@ -188,28 +182,21 @@ export const createPublicOrder = async (req: Request, res: Response, next: NextF
     // Paystack orders settle into the form's tenant Paystack account; without
     // a tenant we'd create an orphaned unpaid order. Fail fast before any DB write.
     if (isPaystack && !formTenantId) {
-      rejectSubmission(
-        res,
-        slug,
-        'This checkout form is not attached to a tenant; Paystack cannot be initialized.',
-        formData
-      );
+      reject('This checkout form is not attached to a tenant; Paystack cannot be initialized.');
       return;
     }
 
     if (isDigital && !formData.email) {
-      rejectSubmission(res, slug, 'Email is required for digital products', formData);
+      reject('Email is required for digital products');
       return;
     }
 
-    // Check if customer exists or create new one (scoped to tenant). Archived
-    // customers are found and reactivated — they still hold the phone number's
-    // slot in the unique index, so creating past them would 500.
+    // Check if customer exists or create new one (scoped to tenant).
     let customer = await findAndReactivateCustomerByPhone(
       prisma,
       formData.phoneNumber,
-      formTenantId,
-      'public checkout'
+      'public checkout',
+      formTenantId
     );
 
     if (!customer) {

--- a/backend/src/services/checkoutFormService.ts
+++ b/backend/src/services/checkoutFormService.ts
@@ -1,4 +1,5 @@
 import prisma from '../utils/prisma';
+import { withSoftDeleted } from '../utils/prismaExtensions';
 import { AppError } from '../middleware/errorHandler';
 import { Prisma } from '@prisma/client';
 import logger from '../utils/logger';
@@ -154,13 +155,22 @@ export class CheckoutFormService {
    */
   async createCheckoutForm(data: CreateCheckoutFormData) {
 
-    // Check if slug already exists
-    const existingForm = await prisma.checkoutForm.findFirst({
-      where: { slug: data.slug }
-    });
+    // Check if slug already exists. Archived forms still hold their slug in the
+    // unique index and are hidden by the soft-delete filter, so this lookup opts
+    // out — otherwise the create below dies on the constraint with a 500.
+    const existingForm = await withSoftDeleted(() =>
+      prisma.checkoutForm.findFirst({
+        where: { slug: data.slug }
+      })
+    );
 
     if (existingForm) {
-      throw new AppError('Checkout form with this slug already exists', 400);
+      throw new AppError(
+        existingForm.isActive === false
+          ? 'An archived checkout form already uses this slug. Restore it or pick another slug.'
+          : 'Checkout form with this slug already exists',
+        400
+      );
     }
 
     // Validate product exists
@@ -474,12 +484,20 @@ export class CheckoutFormService {
 
     // If updating slug, check for duplicates
     if (data.slug && data.slug !== existingForm.slug) {
-      const slugExists = await prisma.checkoutForm.findFirst({
-        where: { slug: data.slug }
-      });
+      // Archived forms included — see createCheckoutForm.
+      const slugExists = await withSoftDeleted(() =>
+        prisma.checkoutForm.findFirst({
+          where: { slug: data.slug }
+        })
+      );
 
       if (slugExists) {
-        throw new AppError('Slug already in use', 400);
+        throw new AppError(
+          slugExists.isActive === false
+            ? 'An archived checkout form already uses this slug. Restore it or pick another slug.'
+            : 'Slug already in use',
+          400
+        );
       }
     }
 

--- a/backend/src/services/customerService.ts
+++ b/backend/src/services/customerService.ts
@@ -4,6 +4,7 @@ import { Prisma } from '@prisma/client';
 import logger from '../utils/logger';
 import { Requester } from '../utils/authUtils';
 import { getTenantId } from '../utils/tenantContext';
+import { findCustomerByPhoneIncludingArchived } from '../utils/customerLookup';
 
 interface CreateCustomerData {
   firstName: string;
@@ -193,13 +194,18 @@ export class CustomerService {
    * Create new customer
    */
   async createCustomer(data: CreateCustomerData) {
-    // Check if customer with phone number already exists
-    const existingCustomer = await prisma.customer.findFirst({
-      where: { phoneNumber: data.phoneNumber }
-    });
+    // Check if customer with phone number already exists. Archived customers
+    // count: they still hold the number in the unique index, so missing one here
+    // turns a clean 400 into a constraint-violation 500.
+    const existingCustomer = await findCustomerByPhoneIncludingArchived(prisma, data.phoneNumber);
 
     if (existingCustomer) {
-      throw new AppError('Customer with this phone number already exists', 400);
+      throw new AppError(
+        existingCustomer.isActive === false
+          ? 'An archived customer already uses this phone number. Restore that customer instead.'
+          : 'Customer with this phone number already exists',
+        400
+      );
     }
 
     const customer = await prisma.customer.create({
@@ -356,12 +362,19 @@ export class CustomerService {
 
     // If updating phone number, check for duplicates
     if (updateData.phoneNumber && updateData.phoneNumber !== customer.phoneNumber) {
-      const existingCustomer = await prisma.customer.findFirst({
-        where: { phoneNumber: updateData.phoneNumber }
-      });
+      // Archived customers included — see createCustomer.
+      const existingCustomer = await findCustomerByPhoneIncludingArchived(
+        prisma,
+        updateData.phoneNumber
+      );
 
       if (existingCustomer) {
-        throw new AppError('Phone number already in use', 400);
+        throw new AppError(
+          existingCustomer.isActive === false
+            ? 'Phone number already in use by an archived customer'
+            : 'Phone number already in use',
+          400
+        );
       }
     }
 

--- a/backend/src/services/orderService.ts
+++ b/backend/src/services/orderService.ts
@@ -223,15 +223,8 @@ export class OrderService {
         throw new AppError('Customer not found', 404);
       }
     } else if (data.customerPhone) {
-      // Find customer by phone or create new one. Archived customers count as
-      // found (and are reactivated) — they still own the phone number in the
-      // unique index, so creating past one would fail.
-      customer = await findAndReactivateCustomerByPhone(
-        prisma,
-        data.customerPhone,
-        undefined,
-        'manual order'
-      );
+      // Find customer by phone or create new one.
+      customer = await findAndReactivateCustomerByPhone(prisma, data.customerPhone, 'manual order');
 
       if (!customer) {
         // Parse customer name
@@ -531,11 +524,9 @@ export class OrderService {
 
           const createdOrder = await prisma.$transaction(async (tx) => {
             // 3. Find or create customer by phone (tenant-scoped via Prisma extension).
-            // Archived customers are found and reactivated rather than duplicated.
             let customer = await findAndReactivateCustomerByPhone(
               tx,
               orderData.customerPhone,
-              undefined,
               'bulk import'
             );
             if (customer) {

--- a/backend/src/services/orderService.ts
+++ b/backend/src/services/orderService.ts
@@ -19,6 +19,7 @@ import { SYSTEM_USER_ID } from '../config/constants';
 import { GLAutomationService, JournalEntryWithTransactions } from './glAutomationService';
 import FinancialSyncService from './financialSyncService';
 import agentInventoryService from './agentInventoryService';
+import { findAndReactivateCustomerByPhone } from '../utils/customerLookup';
 
 
 
@@ -222,10 +223,15 @@ export class OrderService {
         throw new AppError('Customer not found', 404);
       }
     } else if (data.customerPhone) {
-      // Find customer by phone or create new one
-      customer = await prisma.customer.findFirst({
-        where: { phoneNumber: data.customerPhone }
-      });
+      // Find customer by phone or create new one. Archived customers count as
+      // found (and are reactivated) — they still own the phone number in the
+      // unique index, so creating past one would fail.
+      customer = await findAndReactivateCustomerByPhone(
+        prisma,
+        data.customerPhone,
+        undefined,
+        'manual order'
+      );
 
       if (!customer) {
         // Parse customer name
@@ -524,10 +530,14 @@ export class OrderService {
           }
 
           const createdOrder = await prisma.$transaction(async (tx) => {
-            // 3. Find or create customer by phone (tenant-scoped via Prisma extension)
-            let customer = await tx.customer.findFirst({
-              where: { phoneNumber: orderData.customerPhone },
-            });
+            // 3. Find or create customer by phone (tenant-scoped via Prisma extension).
+            // Archived customers are found and reactivated rather than duplicated.
+            let customer = await findAndReactivateCustomerByPhone(
+              tx,
+              orderData.customerPhone,
+              undefined,
+              'bulk import'
+            );
             if (customer) {
               customer = await tx.customer.update({
                 where: { id: customer.id },

--- a/backend/src/services/webhookService.ts
+++ b/backend/src/services/webhookService.ts
@@ -626,14 +626,7 @@ export class WebhookService {
     }
 
 
-    // Archived customers are found and reactivated — they still hold the phone
-    // number's slot in the unique index, so creating past one would fail.
-    let customer = await findAndReactivateCustomerByPhone(
-      prisma,
-      customerPhone,
-      undefined,
-      'webhook intake'
-    );
+    let customer = await findAndReactivateCustomerByPhone(prisma, customerPhone, 'webhook intake');
 
     if (!customer) {
       customer = await prisma.customer.create({

--- a/backend/src/services/webhookService.ts
+++ b/backend/src/services/webhookService.ts
@@ -7,6 +7,7 @@ import workflowService from './workflowService';
 import { getSocketInstance } from '../utils/socketInstance';
 import { emitOrderCreated } from '../sockets';
 import { tenantStorage } from '../utils/tenantContext';
+import { findAndReactivateCustomerByPhone } from '../utils/customerLookup';
 
 
 interface CreateWebhookData {
@@ -625,9 +626,14 @@ export class WebhookService {
     }
 
 
-    let customer = await prisma.customer.findFirst({
-      where: { phoneNumber: customerPhone }
-    });
+    // Archived customers are found and reactivated — they still hold the phone
+    // number's slot in the unique index, so creating past one would fail.
+    let customer = await findAndReactivateCustomerByPhone(
+      prisma,
+      customerPhone,
+      undefined,
+      'webhook intake'
+    );
 
     if (!customer) {
       customer = await prisma.customer.create({

--- a/backend/src/utils/customerLookup.ts
+++ b/backend/src/utils/customerLookup.ts
@@ -1,0 +1,79 @@
+import { Customer, Prisma } from '@prisma/client';
+import { withSoftDeleted } from './prismaExtensions';
+import logger from './logger';
+
+/**
+ * Customer find-or-create, archive-aware.
+ *
+ * Archiving a customer sets `isActive: false`; the row stays in the table and
+ * keeps occupying the `@@unique([phoneNumber, tenantId])` index. The soft-delete
+ * extension auto-injects `isActive: true` into every read, so a plain
+ * `findFirst({ where: { phoneNumber } })` cannot see archived customers — a
+ * find-then-create against an archived phone number finds nothing, creates a
+ * duplicate, and dies on the unique constraint with a 500.
+ *
+ * Every path that turns an inbound phone number into a customer must go through
+ * here so an archived record is found rather than re-created.
+ */
+
+/**
+ * Structural client type: satisfied by both the extended `prisma` singleton and
+ * a `$transaction` client, so callers inside a transaction stay in it.
+ */
+export interface CustomerCapableClient {
+  customer: {
+    findFirst(args: { where: Prisma.CustomerWhereInput }): Promise<Customer | null>;
+    update(args: {
+      where: Prisma.CustomerWhereUniqueInput;
+      data: Prisma.CustomerUpdateInput;
+    }): Promise<Customer>;
+  };
+}
+
+/**
+ * Finds a customer by phone number, archived records included.
+ *
+ * `tenantId` is only needed on public/unauthenticated paths, where there is no
+ * tenant context for the isolation extension to inject; authenticated callers
+ * omit it and let the extension scope the query.
+ */
+export async function findCustomerByPhoneIncludingArchived(
+  db: CustomerCapableClient,
+  phoneNumber: string,
+  tenantId?: string | null
+): Promise<Customer | null> {
+  return withSoftDeleted(() =>
+    db.customer.findFirst({
+      where: { phoneNumber, ...(tenantId ? { tenantId } : {}) },
+    })
+  );
+}
+
+/**
+ * Finds a customer by phone number and un-archives them if they were archived.
+ *
+ * Used by the order-intake paths: a new order against an archived phone number
+ * means that person is a customer again, so the record is restored rather than
+ * left invisible. Returns null when no record exists at all (caller creates one).
+ */
+export async function findAndReactivateCustomerByPhone(
+  db: CustomerCapableClient,
+  phoneNumber: string,
+  tenantId?: string | null,
+  context?: string
+): Promise<Customer | null> {
+  const customer = await findCustomerByPhoneIncludingArchived(db, phoneNumber, tenantId);
+  // Only an explicit false is archived — never write on an absent/unknown flag.
+  if (!customer || customer.isActive !== false) return customer;
+
+  logger.info('Reactivating archived customer for new order', {
+    customerId: customer.id,
+    phoneNumber: customer.phoneNumber,
+    context: context || 'unknown',
+  });
+
+  return db.customer.update({
+    where: { id: customer.id },
+    data: { isActive: true },
+  });
+}

--- a/backend/src/utils/customerLookup.ts
+++ b/backend/src/utils/customerLookup.ts
@@ -1,4 +1,5 @@
-import { Customer, Prisma } from '@prisma/client';
+import { Customer } from '@prisma/client';
+import type { TransactionClient } from './prisma';
 import { withSoftDeleted } from './prismaExtensions';
 import logger from './logger';
 
@@ -17,28 +18,17 @@ import logger from './logger';
  */
 
 /**
- * Structural client type: satisfied by both the extended `prisma` singleton and
- * a `$transaction` client, so callers inside a transaction stay in it.
- */
-export interface CustomerCapableClient {
-  customer: {
-    findFirst(args: { where: Prisma.CustomerWhereInput }): Promise<Customer | null>;
-    update(args: {
-      where: Prisma.CustomerWhereUniqueInput;
-      data: Prisma.CustomerUpdateInput;
-    }): Promise<Customer>;
-  };
-}
-
-/**
  * Finds a customer by phone number, archived records included.
+ *
+ * `db` accepts the extended `prisma` singleton or a `$transaction` client, so
+ * callers already inside a transaction stay in it.
  *
  * `tenantId` is only needed on public/unauthenticated paths, where there is no
  * tenant context for the isolation extension to inject; authenticated callers
  * omit it and let the extension scope the query.
  */
 export async function findCustomerByPhoneIncludingArchived(
-  db: CustomerCapableClient,
+  db: TransactionClient,
   phoneNumber: string,
   tenantId?: string | null
 ): Promise<Customer | null> {
@@ -55,12 +45,14 @@ export async function findCustomerByPhoneIncludingArchived(
  * Used by the order-intake paths: a new order against an archived phone number
  * means that person is a customer again, so the record is restored rather than
  * left invisible. Returns null when no record exists at all (caller creates one).
+ *
+ * `context` names the intake path in the reactivation log line.
  */
 export async function findAndReactivateCustomerByPhone(
-  db: CustomerCapableClient,
+  db: TransactionClient,
   phoneNumber: string,
-  tenantId?: string | null,
-  context?: string
+  context: string,
+  tenantId?: string | null
 ): Promise<Customer | null> {
   const customer = await findCustomerByPhoneIncludingArchived(db, phoneNumber, tenantId);
   // Only an explicit false is archived — never write on an absent/unknown flag.
@@ -69,7 +61,7 @@ export async function findAndReactivateCustomerByPhone(
   logger.info('Reactivating archived customer for new order', {
     customerId: customer.id,
     phoneNumber: customer.phoneNumber,
-    context: context || 'unknown',
+    context,
   });
 
   return db.customer.update({

--- a/frontend/src/__tests__/lib/standardFields.test.ts
+++ b/frontend/src/__tests__/lib/standardFields.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { FormField } from '../../types/checkout-form';
+import { findMissingRequiredKeys, mapFields, resolveStandardKey } from '../../lib/standardFields';
+
+function field(overrides: Partial<FormField> & { label: string }): FormField {
+  return {
+    id: overrides.label,
+    type: 'text',
+    required: false,
+    enabled: true,
+    ...overrides,
+  };
+}
+
+describe('resolveStandardKey', () => {
+  // The bug this whole module exists for: a tenant labelled their address field
+  // "Delivery Address", it matched no alias, the value went to customFields, and
+  // every order they took was rejected for a missing address.
+  it('maps address labels merchants actually use', () => {
+    for (const label of [
+      'Street Address',
+      'Delivery Address',
+      'Shipping Address',
+      'House Address',
+      'Address',
+    ]) {
+      expect(resolveStandardKey(field({ label, type: 'textarea' }))).toBe('streetAddress');
+    }
+  });
+
+  it('maps a WhatsApp number to the alternate phone slot', () => {
+    expect(resolveStandardKey(field({ label: 'Whatsapp Number', type: 'phone' }))).toBe(
+      'alternativePhone'
+    );
+  });
+
+  it('ignores case, trailing colons and required markers on the label', () => {
+    expect(resolveStandardKey(field({ label: '  DELIVERY ADDRESS: *' }))).toBe('streetAddress');
+  });
+
+  it('prefers an explicit standardKey over the label', () => {
+    const f = field({ label: 'Where should we drop it?', standardKey: 'streetAddress' });
+    expect(resolveStandardKey(f)).toBe('streetAddress');
+  });
+
+  it("honours 'custom' as a pin, even on a label that would otherwise match", () => {
+    expect(resolveStandardKey(field({ label: 'Address', standardKey: 'custom' }))).toBeNull();
+  });
+
+  it('falls back to the field type when the label matches nothing', () => {
+    expect(resolveStandardKey(field({ label: 'Where do you live?', type: 'state' }))).toBe('region');
+    expect(resolveStandardKey(field({ label: 'Contact me at', type: 'email' }))).toBe('email');
+  });
+
+  it('leaves genuinely custom fields unmapped', () => {
+    expect(resolveStandardKey(field({ label: 'How did you hear about us?' }))).toBeNull();
+    // "City" is deliberately not a region alias — a form may carry both.
+    expect(resolveStandardKey(field({ label: 'City' }))).toBeNull();
+  });
+});
+
+describe('mapFields', () => {
+  it('routes standard fields to payload keys and the rest to customFields', () => {
+    const mapped = mapFields([
+      field({ label: 'Full Name' }),
+      field({ label: 'Delivery Address', type: 'textarea' }),
+      field({ label: 'How did you hear about us?' }),
+    ]);
+
+    expect(mapped.map((m) => m.formKey)).toEqual([
+      'fullName',
+      'streetAddress',
+      'customFields.How did you hear about us?',
+    ]);
+  });
+
+  it('gives a standard slot to the first claimant and demotes later duplicates', () => {
+    const mapped = mapFields([
+      field({ label: 'Phone Number', type: 'phone' }),
+      field({ label: 'Phone', type: 'phone' }),
+    ]);
+
+    // Without this, the second field would overwrite the first buyer's number.
+    expect(mapped[0].standardKey).toBe('phone');
+    expect(mapped[1].standardKey).toBeNull();
+    expect(mapped[1].formKey).toBe('customFields.Phone');
+  });
+});
+
+describe('findMissingRequiredKeys', () => {
+  const physicalFields = [
+    field({ label: 'Full Name' }),
+    field({ label: 'Phone', type: 'phone' }),
+    field({ label: 'Delivery Address', type: 'textarea' }),
+    field({ label: 'Region', type: 'state' }),
+  ];
+
+  it('passes a form that feeds every required slot', () => {
+    expect(findMissingRequiredKeys(physicalFields)).toEqual([]);
+  });
+
+  it('flags the slot a mislabelled field left empty', () => {
+    const broken = physicalFields.map((f) =>
+      f.label === 'Delivery Address' ? { ...f, standardKey: 'custom' as const } : f
+    );
+    expect(findMissingRequiredKeys(broken)).toEqual(['streetAddress']);
+  });
+
+  it('ignores disabled fields', () => {
+    const disabled = physicalFields.map((f) =>
+      f.label === 'Region' ? { ...f, enabled: false } : f
+    );
+    expect(findMissingRequiredKeys(disabled)).toEqual(['region']);
+  });
+
+  it('requires email but not address for digital products', () => {
+    expect(findMissingRequiredKeys(physicalFields, { isDigital: true })).toEqual(['email']);
+  });
+});

--- a/frontend/src/components/forms/CheckoutFormBuilder.tsx
+++ b/frontend/src/components/forms/CheckoutFormBuilder.tsx
@@ -47,12 +47,17 @@ interface CheckoutFormBuilderProps {
   onDraftChange?: (draft: Record<string, any>) => void;
 }
 
+// Destinations are pinned via standardKey so relabeling any of these (e.g.
+// "Street Address" → "Delivery Address") keeps the value flowing to the order.
+// The region field is part of the default set because a physical order without
+// one is rejected by the order API.
 const defaultFields: FormField[] = [
-  { id: '1', label: 'Full Name', type: 'text', required: true, enabled: true },
-  { id: '2', label: 'Phone', type: 'phone', required: true, enabled: true },
-  { id: '3', label: 'Alt Phone', type: 'phone', required: false, enabled: true },
-  { id: '4', label: 'Email Address', type: 'email', required: false, enabled: true },
-  { id: '5', label: 'Street Address', type: 'textarea', required: true, enabled: true },
+  { id: '1', label: 'Full Name', type: 'text', required: true, enabled: true, standardKey: 'fullName' },
+  { id: '2', label: 'Phone', type: 'phone', required: true, enabled: true, standardKey: 'phone' },
+  { id: '3', label: 'Alt Phone', type: 'phone', required: false, enabled: true, standardKey: 'alternativePhone' },
+  { id: '4', label: 'Email Address', type: 'email', required: false, enabled: true, standardKey: 'email' },
+  { id: '5', label: 'Street Address', type: 'textarea', required: true, enabled: true, standardKey: 'streetAddress' },
+  { id: '6', label: 'Region/State', type: 'state', required: true, enabled: true, standardKey: 'region' },
 ];
 
 export const CheckoutFormBuilder = forwardRef<CheckoutFormBuilderHandle, CheckoutFormBuilderProps>(({

--- a/frontend/src/components/forms/FieldEditModal.tsx
+++ b/frontend/src/components/forms/FieldEditModal.tsx
@@ -4,8 +4,9 @@ import { Modal } from '../ui/Modal';
 import { Button } from '../ui/Button';
 import { Input } from '../ui/Input';
 import { Select } from '../ui/Select';
-import { FieldType, FormField } from '../../types/checkout-form';
+import { FieldType, FormField, StandardFieldKey } from '../../types/checkout-form';
 import { FIELD_TYPES, getFieldTypeMeta } from './builder/fieldTypes';
+import { STANDARD_FIELDS, getStandardFieldMeta, resolveStandardKey } from '../../lib/standardFields';
 
 interface FieldEditModalProps {
   field: FormField;
@@ -15,12 +16,25 @@ interface FieldEditModalProps {
 
 const typeOptions = FIELD_TYPES.map((t) => ({ value: t.type, label: t.label }));
 
+// '' = infer from the label (the behaviour for every field built before this
+// picker existed). Anything else pins the destination so the label can be
+// reworded freely without the value silently stopping at customFields.
+const destinationOptions = [
+  { value: '', label: 'Auto — detect from label' },
+  ...STANDARD_FIELDS.map((f) => ({ value: f.key, label: f.label })),
+  { value: 'custom', label: 'Custom field (kept with the order, not delivered on)' },
+];
+
 export const FieldEditModal: React.FC<FieldEditModalProps> = ({ field, onClose, onSave }) => {
   const [draft, setDraft] = useState<FormField>(field);
   const typeMeta = getFieldTypeMeta(draft.type);
   const showOptions = typeMeta.hasOptions;
   const labelEmpty = !draft.label.trim();
   const options = draft.options ?? [];
+  // Where this field's value will actually land, under the current label and
+  // destination setting — shown live so a mis-mapped field is visible here
+  // rather than discovered as a rejected order.
+  const resolvedKey = resolveStandardKey(draft);
 
   const update = (patch: Partial<FormField>) => setDraft((prev) => ({ ...prev, ...patch }));
 
@@ -73,6 +87,23 @@ export const FieldEditModal: React.FC<FieldEditModalProps> = ({ field, onClose, 
             placeholder="e.g., Full Name"
           />
           {labelEmpty && <p className="text-xs text-red-500 mt-1">Label is required</p>}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Sends To</label>
+          <Select
+            options={destinationOptions}
+            value={draft.standardKey ?? ''}
+            onChange={(e) => {
+              const v = e.target.value;
+              update({ standardKey: v === '' ? undefined : (v as StandardFieldKey | 'custom') });
+            }}
+          />
+          <p className="text-xs text-gray-500 mt-1">
+            {resolvedKey
+              ? `This field's value is delivered as the order's ${getStandardFieldMeta(resolvedKey)?.label.toLowerCase()}.`
+              : 'This value is saved with the order but is not used as the name, phone, address or region.'}
+          </p>
         </div>
 
         <div>

--- a/frontend/src/components/forms/builder/FieldsTab.tsx
+++ b/frontend/src/components/forms/builder/FieldsTab.tsx
@@ -13,24 +13,25 @@ import {
   useSortable,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { FormField } from '../../../types/checkout-form';
+import { FormField, StandardFieldKey } from '../../../types/checkout-form';
 import { FIELD_TYPES, getFieldTypeMeta } from './fieldTypes';
 import { FieldEditModal } from '../FieldEditModal';
 import { useCheckoutBuilder } from './checkoutBuilderContextValue';
 import {
   findMissingRequiredKeys,
   getStandardFieldMeta,
-  resolveStandardKey,
+  mapFields,
 } from '../../../lib/standardFields';
 
 interface FieldRowProps {
   field: FormField;
+  standardKey: StandardFieldKey | null;
   onEdit: () => void;
   onToggleRequired: () => void;
   onDelete: () => void;
 }
 
-const FieldRow: React.FC<FieldRowProps> = ({ field, onEdit, onToggleRequired, onDelete }) => {
+const FieldRow: React.FC<FieldRowProps> = ({ field, standardKey, onEdit, onToggleRequired, onDelete }) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: field.id,
   });
@@ -44,7 +45,7 @@ const FieldRow: React.FC<FieldRowProps> = ({ field, onEdit, onToggleRequired, on
   // Where this field's value lands. "Custom" is legitimate for extra questions,
   // but it's also what a mislabelled address field silently becomes, so it's
   // shown on every row rather than only on the standard ones.
-  const destination = getStandardFieldMeta(resolveStandardKey(field))?.label ?? 'Custom';
+  const destination = getStandardFieldMeta(standardKey)?.label ?? 'Custom';
 
   return (
     <div
@@ -123,6 +124,14 @@ export const FieldsTab: React.FC = () => {
     ctx.products.find((p) => p.id === productId)?.productType === 'digital';
   const missingKeys = findMissingRequiredKeys(ctx.fields, { isDigital });
 
+  // Rows show the destination each field actually WINS, not the one its label
+  // resolves to: when two fields resolve to the same slot only the first claims
+  // it, and a row that claimed nothing must read "Custom" so the disagreement is
+  // visible here. Mapped over the enabled fields only, matching the banner above.
+  const claimedKeyByFieldId = new Map(
+    mapFields(ctx.fields.filter((f) => f.enabled !== false)).map((m) => [m.field.id, m.standardKey])
+  );
+
   return (
     <div className="space-y-6">
       {missingKeys.length > 0 && (
@@ -189,6 +198,7 @@ export const FieldsTab: React.FC = () => {
                   <FieldRow
                     key={field.id}
                     field={field}
+                    standardKey={claimedKeyByFieldId.get(field.id) ?? null}
                     onEdit={() => setEditingFieldId(field.id)}
                     onToggleRequired={() =>
                       ctx.updateField(field.id, { ...field, required: !field.required })

--- a/frontend/src/components/forms/builder/FieldsTab.tsx
+++ b/frontend/src/components/forms/builder/FieldsTab.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Pencil, Trash2, GripVertical } from 'lucide-react';
+import { Pencil, Trash2, GripVertical, AlertTriangle } from 'lucide-react';
 import {
   DndContext,
   closestCenter,
@@ -17,6 +17,11 @@ import { FormField } from '../../../types/checkout-form';
 import { FIELD_TYPES, getFieldTypeMeta } from './fieldTypes';
 import { FieldEditModal } from '../FieldEditModal';
 import { useCheckoutBuilder } from './checkoutBuilderContextValue';
+import {
+  findMissingRequiredKeys,
+  getStandardFieldMeta,
+  resolveStandardKey,
+} from '../../../lib/standardFields';
 
 interface FieldRowProps {
   field: FormField;
@@ -36,6 +41,10 @@ const FieldRow: React.FC<FieldRowProps> = ({ field, onEdit, onToggleRequired, on
   };
   const meta = getFieldTypeMeta(field.type);
   const Icon = meta.icon;
+  // Where this field's value lands. "Custom" is legitimate for extra questions,
+  // but it's also what a mislabelled address field silently becomes, so it's
+  // shown on every row rather than only on the standard ones.
+  const destination = getStandardFieldMeta(resolveStandardKey(field))?.label ?? 'Custom';
 
   return (
     <div
@@ -55,7 +64,9 @@ const FieldRow: React.FC<FieldRowProps> = ({ field, onEdit, onToggleRequired, on
 
       <div className="min-w-0 flex-1">
         <p className="font-semibold text-gray-900 truncate">{field.label}</p>
-        <p className="text-xs text-gray-500">{meta.label}</p>
+        <p className="text-xs text-gray-500">
+          {meta.label} <span className="text-gray-400">·</span> sends to {destination}
+        </p>
       </div>
 
       {field.required && (
@@ -104,8 +115,34 @@ export const FieldsTab: React.FC = () => {
   const [editingFieldId, setEditingFieldId] = useState<string | null>(null);
   const editingField = ctx.fields.find((f) => f.id === editingFieldId) || null;
 
+  // A required destination with no field feeding it means the order API rejects
+  // every submission this form makes — surface it here, where it's fixable,
+  // instead of letting the form go live and take zero orders.
+  const productId = ctx.watch('productId');
+  const isDigital =
+    ctx.products.find((p) => p.id === productId)?.productType === 'digital';
+  const missingKeys = findMissingRequiredKeys(ctx.fields, { isDigital });
+
   return (
     <div className="space-y-6">
+      {missingKeys.length > 0 && (
+        <div className="flex gap-3 rounded-lg border border-amber-300 bg-amber-50 p-4">
+          <AlertTriangle className="h-5 w-5 flex-shrink-0 text-amber-600" />
+          <div className="text-sm">
+            <p className="font-semibold text-amber-900">
+              This form can’t take orders yet
+            </p>
+            <p className="mt-1 text-amber-800">
+              Nothing is sending the customer’s{' '}
+              <strong>
+                {missingKeys.map((k) => getStandardFieldMeta(k)?.label.toLowerCase()).join(', ')}
+              </strong>
+              . Add a field for it, or open an existing field and set “Sends To”.
+            </p>
+          </div>
+        </div>
+      )}
+
       {/* Add Form Fields */}
       <div className="border-2 border-dashed border-gray-300 rounded-xl p-5">
         <h3 className="text-base font-semibold text-gray-900 mb-4">Add Form Fields</h3>

--- a/frontend/src/components/public/CheckoutForm.tsx
+++ b/frontend/src/components/public/CheckoutForm.tsx
@@ -34,6 +34,10 @@ export interface CheckoutFormData {
   paymentMethod?: PaymentMethod;
 }
 
+// Which slots default to required when the field itself doesn't say. Not the same
+// thing as `REQUIRED_PHYSICAL` in lib/standardFields (which is what the server
+// rejects a submission without) — this one also applies to digital forms, where
+// address and region are still asked for but the server doesn't demand them.
 const DEFAULT_REQUIRED_KEYS: ReadonlySet<string> = new Set(['fullName', 'phone', 'region', 'streetAddress']);
 
 const DEFAULT_FIELDS: FormField[] = [

--- a/frontend/src/components/public/CheckoutForm.tsx
+++ b/frontend/src/components/public/CheckoutForm.tsx
@@ -1,7 +1,8 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { useForm, RegisterOptions, FieldError } from 'react-hook-form';
 import { PublicCheckoutForm } from '../../services/public-orders.service';
-import { FieldType, FormField, PaymentMethod } from '../../types/checkout-form';
+import { FormField, PaymentMethod } from '../../types/checkout-form';
+import { MappedField, mapFields } from '../../lib/standardFields';
 import { PackageSelector } from './PackageSelector';
 import { AddOnSelector } from './AddOnSelector';
 import { OrderSummary, PaymentMethodOption } from './OrderSummary';
@@ -33,50 +34,16 @@ export interface CheckoutFormData {
   paymentMethod?: PaymentMethod;
 }
 
-interface StandardFieldConfig {
-  key: keyof CheckoutFormData;
-  aliases: string[];
-}
-
-const STANDARD_FIELDS: StandardFieldConfig[] = [
-  { key: 'fullName', aliases: ['name', 'full name'] },
-  { key: 'phone', aliases: ['phone', 'phone number'] },
-  { key: 'alternativePhone', aliases: ['alt phone', 'alternative phone', 'alt. phone'] },
-  { key: 'email', aliases: ['email', 'e-mail'] },
-  { key: 'region', aliases: ['region', 'region/state', 'state'] },
-  { key: 'streetAddress', aliases: ['street address', 'address'] },
-];
-
 const DEFAULT_REQUIRED_KEYS: ReadonlySet<string> = new Set(['fullName', 'phone', 'region', 'streetAddress']);
 
 const DEFAULT_FIELDS: FormField[] = [
-  { id: 'fullName', label: 'Full Name', type: 'text', required: true, enabled: true },
-  { id: 'phone', label: 'Phone', type: 'phone', required: true, enabled: true },
-  { id: 'altPhone', label: 'Alt Phone', type: 'phone', required: false, enabled: true },
-  { id: 'email', label: 'Email Address', type: 'email', required: false, enabled: true },
-  { id: 'region', label: 'Region/State', type: 'select', required: true, enabled: true },
-  { id: 'streetAddress', label: 'Street Address', type: 'textarea', required: true, enabled: true },
+  { id: 'fullName', label: 'Full Name', type: 'text', required: true, enabled: true, standardKey: 'fullName' },
+  { id: 'phone', label: 'Phone', type: 'phone', required: true, enabled: true, standardKey: 'phone' },
+  { id: 'altPhone', label: 'Alt Phone', type: 'phone', required: false, enabled: true, standardKey: 'alternativePhone' },
+  { id: 'email', label: 'Email Address', type: 'email', required: false, enabled: true, standardKey: 'email' },
+  { id: 'region', label: 'Region/State', type: 'select', required: true, enabled: true, standardKey: 'region' },
+  { id: 'streetAddress', label: 'Street Address', type: 'textarea', required: true, enabled: true, standardKey: 'streetAddress' },
 ];
-
-// Field types the builder emits 1:1 onto a standard key, used to map a field
-// whose label doesn't match an alias (e.g. the builder's default "Email Address"
-// label). Only the unambiguous types are listed: `phone` is excluded because it
-// covers both phone and altPhone, and `text`/`textarea` can be any custom field.
-const TYPE_TO_STANDARD_KEY: Partial<Record<FieldType, keyof CheckoutFormData>> = {
-  email: 'email',
-  state: 'region',
-};
-
-function getStandardField(field: FormField): StandardFieldConfig | null {
-  const normalized = field.label.toLowerCase().trim();
-  const byAlias = STANDARD_FIELDS.find(config => config.aliases.includes(normalized));
-  if (byAlias) return byAlias;
-  // Fall back to the field's explicit type so a relabeled standard field (most
-  // commonly an email field labeled "Email Address") still registers under its
-  // standard key instead of leaking into customFields and being dropped.
-  const typeKey = TYPE_TO_STANDARD_KEY[field.type];
-  return typeKey ? STANDARD_FIELDS.find(config => config.key === typeKey) ?? null : null;
-}
 
 interface FieldWrapperProps {
   fieldKey: string;
@@ -137,11 +104,11 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ formData, onSubmit, 
 
   const selectedPackage = formData.packages.find((p) => p.id === selectedPackageId) || null;
 
-  function getFieldsToRender(): FormField[] {
-    if (!formData.fields?.length) {
-      return DEFAULT_FIELDS;
-    }
-    return formData.fields.filter((f: FormField) => f.enabled !== false);
+  function getFieldsToRender(): MappedField[] {
+    const fields = formData.fields?.length
+      ? formData.fields.filter((f: FormField) => f.enabled !== false)
+      : DEFAULT_FIELDS;
+    return mapFields(fields);
   }
 
   function getFieldError(formKey: string): FieldError | undefined {
@@ -193,12 +160,10 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ formData, onSubmit, 
   // name/options don't line up with the static CheckoutFormData type — cast once here.
   const reg = (key: string, opts?: RegisterOptions) => register(key as any, opts as any);
 
-  function renderField(field: FormField): React.JSX.Element {
-    const standard = getStandardField(field);
-    const formKey = standard ? standard.key : `customFields.${field.label}`;
-    let isRequired = field.required ?? (standard ? DEFAULT_REQUIRED_KEYS.has(standard.key) : false);
+  function renderField({ field, standardKey, formKey }: MappedField): React.JSX.Element {
+    let isRequired = field.required ?? (standardKey ? DEFAULT_REQUIRED_KEYS.has(standardKey) : false);
     // For digital products: email is always required
-    if (isDigital && (standard?.key === 'email' || field.type === 'email')) isRequired = true;
+    if (isDigital && (standardKey === 'email' || field.type === 'email')) isRequired = true;
     const error = getFieldError(formKey);
     const hasError = !!error;
     const validation: RegisterOptions | undefined = isRequired ? requiredRule(field.label) : undefined;
@@ -210,7 +175,7 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ formData, onSubmit, 
     let control: React.JSX.Element;
 
     // Country-driven states dropdown (region standard key or the explicit "state" type).
-    if (standard?.key === 'region' || field.type === 'state') {
+    if (standardKey === 'region' || field.type === 'state') {
       control = (
         <select {...reg(formKey, validation)} className={selectClassName(hasError)} style={fieldStyle}>
           <option value="">Select {field.label.toLowerCase()}</option>
@@ -219,7 +184,7 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ formData, onSubmit, 
           ))}
         </select>
       );
-    } else if (standard?.key === 'streetAddress' || (!standard && field.type === 'textarea')) {
+    } else if (standardKey === 'streetAddress' || (!standardKey && field.type === 'textarea')) {
       control = (
         <textarea
           {...reg(formKey, validation)}
@@ -229,7 +194,7 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ formData, onSubmit, 
           style={fieldStyle}
         />
       );
-    } else if (!standard && (field.type === 'select' || field.type === 'multiselect')) {
+    } else if (!standardKey && (field.type === 'select' || field.type === 'multiselect')) {
       const isMulti = field.type === 'multiselect';
       control = (
         <select
@@ -244,7 +209,7 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ formData, onSubmit, 
           ))}
         </select>
       );
-    } else if (!standard && field.type === 'checkbox') {
+    } else if (!standardKey && field.type === 'checkbox') {
       const checkboxOptions = field.options || [];
       control = (
         <div className="space-y-2">
@@ -265,7 +230,7 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ formData, onSubmit, 
           )}
         </div>
       );
-    } else if (standard?.key === 'phone' || standard?.key === 'alternativePhone' || (!standard && field.type === 'phone')) {
+    } else if (standardKey === 'phone' || standardKey === 'alternativePhone' || (!standardKey && field.type === 'phone')) {
       const phoneValidation: RegisterOptions = {
         ...(isRequired ? { required: `${field.label} is required` } : {}),
         pattern: {
@@ -276,7 +241,7 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ formData, onSubmit, 
       control = (
         <input {...reg(formKey, phoneValidation)} type="tel" placeholder={placeholder} className={inputClassName(hasError)} style={fieldStyle} />
       );
-    } else if (standard?.key === 'email' || field.type === 'email') {
+    } else if (standardKey === 'email' || field.type === 'email') {
       const emailValidation: RegisterOptions = {
         ...(isRequired ? { required: `${field.label} is required` } : {}),
         pattern: {
@@ -288,7 +253,7 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ formData, onSubmit, 
         <input {...reg(formKey, emailValidation)} type="email" placeholder={placeholder} className={inputClassName(hasError)} style={fieldStyle} />
       );
     } else {
-      const inputType = !standard && field.type === 'number' ? 'number' : 'text';
+      const inputType = !standardKey && field.type === 'number' ? 'number' : 'text';
       control = (
         <input {...reg(formKey, validation)} type={inputType} placeholder={placeholder} className={inputClassName(hasError)} style={fieldStyle} />
       );

--- a/frontend/src/lib/standardFields.ts
+++ b/frontend/src/lib/standardFields.ts
@@ -73,7 +73,7 @@ export const STANDARD_FIELDS: readonly StandardFieldMeta[] = [
       'full address',
     ],
   },
-] as const;
+];
 
 // Field types the builder emits 1:1 onto a standard key, used as the last
 // inference step for a field whose label matches no alias. Only unambiguous

--- a/frontend/src/lib/standardFields.ts
+++ b/frontend/src/lib/standardFields.ts
@@ -1,0 +1,162 @@
+// Resolves which checkout payload slot each form field feeds.
+//
+// A field that resolves to a standard key is posted as that key (`address`,
+// `state`, `phoneNumber`, ...). Anything else is posted under `customFields`,
+// which the order never reads — so a mis-resolved address field means the buyer
+// types their address, the server sees an empty `address`, and the order is
+// rejected. That is a silent, total failure for the form, which is why the
+// builder now writes `standardKey` explicitly and this inference only runs as a
+// fallback for forms built before it existed.
+import { FieldType, FormField, StandardFieldKey } from '../types/checkout-form';
+
+export interface StandardFieldMeta {
+  key: StandardFieldKey;
+  /** Shown in the builder's destination picker. */
+  label: string;
+  /** Lowercased labels that infer this key on forms with no explicit standardKey. */
+  aliases: string[];
+}
+
+// Aliases are matched exactly (after normalisation), not by substring, so an
+// unrelated label can't capture a slot. Ambiguous words are deliberately absent:
+// "city" is not an alias for region, because a form may carry both.
+export const STANDARD_FIELDS: readonly StandardFieldMeta[] = [
+  {
+    key: 'fullName',
+    label: 'Customer name',
+    aliases: ['name', 'full name', 'fullname', 'customer name', 'your name'],
+  },
+  {
+    key: 'phone',
+    label: 'Phone number',
+    aliases: ['phone', 'phone number', 'mobile', 'mobile number', 'telephone', 'contact number'],
+  },
+  {
+    key: 'alternativePhone',
+    label: 'Alternate phone',
+    aliases: [
+      'alt phone',
+      'alt. phone',
+      'alt phone number',
+      'alternate phone',
+      'alternate phone number',
+      'alternative phone',
+      'alternative phone number',
+      'second phone',
+      'second phone number',
+      'other phone number',
+      'whatsapp',
+      'whatsapp number',
+    ],
+  },
+  {
+    key: 'email',
+    label: 'Email address',
+    aliases: ['email', 'e-mail', 'email address'],
+  },
+  {
+    key: 'region',
+    label: 'Region / State',
+    aliases: ['region', 'region/state', 'state', 'state/region', 'province'],
+  },
+  {
+    key: 'streetAddress',
+    label: 'Delivery address',
+    aliases: [
+      'address',
+      'street address',
+      'delivery address',
+      'shipping address',
+      'home address',
+      'house address',
+      'residential address',
+      'full address',
+    ],
+  },
+] as const;
+
+// Field types the builder emits 1:1 onto a standard key, used as the last
+// inference step for a field whose label matches no alias. Only unambiguous
+// types are listed: `phone` covers both phone and alt phone, and
+// `text`/`textarea` can be anything.
+const TYPE_TO_STANDARD_KEY: Partial<Record<FieldType, StandardFieldKey>> = {
+  email: 'email',
+  state: 'region',
+};
+
+export function getStandardFieldMeta(
+  key: StandardFieldKey | null | undefined
+): StandardFieldMeta | undefined {
+  return key ? STANDARD_FIELDS.find((c) => c.key === key) : undefined;
+}
+
+/** Lowercase, drop the required marker and trailing colon, collapse whitespace. */
+function normalizeLabel(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/[*:]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Resolves one field's destination: explicit `standardKey` first, then label
+ * alias, then the field's own type. Returns null for a custom field.
+ */
+export function resolveStandardKey(field: FormField): StandardFieldKey | null {
+  if (field.standardKey) {
+    return field.standardKey === 'custom' ? null : field.standardKey;
+  }
+  const normalized = normalizeLabel(field.label);
+  const byAlias = STANDARD_FIELDS.find((c) => c.aliases.includes(normalized));
+  if (byAlias) return byAlias.key;
+  return TYPE_TO_STANDARD_KEY[field.type] ?? null;
+}
+
+export interface MappedField {
+  field: FormField;
+  standardKey: StandardFieldKey | null;
+  /** react-hook-form path: a standard key, or a `customFields.<label>` path. */
+  formKey: string;
+}
+
+/**
+ * Maps every field to its destination in one pass.
+ *
+ * A standard key is claimed by the first field that resolves to it; a later
+ * field resolving to the same key is demoted to a custom field rather than
+ * silently overwriting the first one's value.
+ */
+export function mapFields(fields: FormField[]): MappedField[] {
+  const claimed = new Set<StandardFieldKey>();
+  return fields.map((field) => {
+    const resolved = resolveStandardKey(field);
+    const standardKey = resolved && !claimed.has(resolved) ? resolved : null;
+    if (standardKey) claimed.add(standardKey);
+    return {
+      field,
+      standardKey,
+      formKey: standardKey ?? `customFields.${field.label}`,
+    };
+  });
+}
+
+// Slots the order API rejects the submission without. Mirrors the required-field
+// check in backend/src/controllers/publicOrderController.ts — if that list
+// changes, change this one.
+const REQUIRED_PHYSICAL: StandardFieldKey[] = ['fullName', 'phone', 'streetAddress', 'region'];
+const REQUIRED_DIGITAL: StandardFieldKey[] = ['fullName', 'phone', 'email'];
+
+/**
+ * Standard slots no enabled field feeds. A non-empty result means the form
+ * cannot produce a valid order: the server will reject every submission.
+ */
+export function findMissingRequiredKeys(
+  fields: FormField[],
+  opts: { isDigital?: boolean } = {}
+): StandardFieldKey[] {
+  const enabled = fields.filter((f) => f.enabled !== false);
+  const present = new Set(mapFields(enabled).map((m) => m.standardKey).filter(Boolean));
+  const required = opts.isDigital ? REQUIRED_DIGITAL : REQUIRED_PHYSICAL;
+  return required.filter((key) => !present.has(key));
+}

--- a/frontend/src/types/checkout-form.ts
+++ b/frontend/src/types/checkout-form.ts
@@ -13,6 +13,16 @@ export type FieldType =
   | 'multiselect'
   | 'state'; // country-driven states dropdown (uses the form's regions list)
 
+// The checkout payload slots a field can feed. Anything not mapped to one of
+// these is sent as a custom field and never reaches the order's own columns.
+export type StandardFieldKey =
+  | 'fullName'
+  | 'phone'
+  | 'alternativePhone'
+  | 'email'
+  | 'region'
+  | 'streetAddress';
+
 export interface FormField {
   id: string; // UI-only ID, not from database
   label: string;
@@ -22,6 +32,11 @@ export interface FormField {
   options?: string[]; // For select / multiselect types
   placeholder?: string;
   widthPercent?: number; // 1-100; controls row width so fields can share a row. Defaults to 100.
+  // Which checkout payload slot this field feeds. Set explicitly in the builder
+  // so the label is free text that can be reworded without breaking the mapping.
+  // 'custom' pins the field to customFields. Absent on forms built before this
+  // existed — those fall back to label/type inference (see lib/standardFields).
+  standardKey?: StandardFieldKey | 'custom';
 }
 
 export interface ProductPackage {


### PR DESCRIPTION
## Why

Five live checkout forms were rejecting **every** submission. Four belong to one tenant who has taken zero orders since signing up.

Two independent faults:

1. **Field mapping keyed off label text.** The checkout decided which payload slot a field fed by matching its human-readable label against a narrow alias list that accepted only "Street Address" or "Address". A tenant labelled theirs "Delivery Address", so the buyer's address landed in `customFields`, `address` arrived empty, and the order API rejected the submission with a 400 — logged nowhere.

2. **Find-or-create blind to archived customers.** Archiving a customer only flips `isActive`; the row keeps the phone number's slot in `@@unique([phoneNumber, tenantId])`. The soft-delete extension hid it, so find-then-create tried to insert a duplicate and died on the constraint. Any repeat buyer whose record had ever been archived was permanently locked out.

## What changed

- `FormField` carries an explicit `standardKey`, set from a "Sends To" picker, so a label can be reworded without breaking the mapping. Pre-existing forms fall back to inference (alias → field type) against a widened alias list.
- A standard slot is claimed by the first field that resolves to it — a duplicate can no longer silently overwrite the first field's value.
- The builder warns when a required slot has no field feeding it, and each field row shows where its value goes.
- All four order-intake paths (public checkout, manual, bulk import, webhook) go through `findAndReactivateCustomerByPhone`, which looks past the soft-delete filter and restores the record.
- Every rejection branch in the public order controller now logs slug + reason + which keys the form sent (keys only, no buyer data).

Follow-on commits: `/simplify` cleanup, and a sweep making the other uniqueness pre-checks (`user.email`, `product.sku`, `checkoutForm.slug`) see archived rows too.

## Verification — replayed against the 9 live production forms

Ran every live form's real field definitions through both the old and new resolver and diffed field-by-field:

```
broken before: 5    fixed: 5    newly broken: 0
```

The only fields whose destination changes are `"Delivery Address"` → street address and `"Whatsapp Number"` / `"Alt Phone Number"` → alternate phone. Both move *out of* `customFields` (which the order never reads) *into* real slots — nothing that was reaching a real slot was taken away. The four already-working forms have zero change to name, phone, address or region.

The moved WhatsApp value was traced end-to-end: it lands in `Customer.alternatePhone` and appears in the order CSV export. No data loss.

- Frontend tests: 152/152
- Backend order-intake tests: 71/71
- Full backend suite: 1029 passed, with the same 12 DB-dependent suites failing as on `develop` (verified identical by name — no new failures)
- Backend + frontend builds, lint: clean

## Staging check before production

1. Submit `prsbioticsshop-scar2` — order should appear with the address populated.
2. Submit the same phone number again — should create a second order, not error (archived-customer path).
3. Submit one Magic Groove order — confirms the already-working forms still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)